### PR TITLE
refactor: 모임 상세보기의 케밥 모달 임시 구현

### DIFF
--- a/src/main/java/com/zpop/web/controller/HomeController.java
+++ b/src/main/java/com/zpop/web/controller/HomeController.java
@@ -1,0 +1,12 @@
+package com.zpop.web.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class HomeController {
+    @RequestMapping("/")
+    public String root() {
+        return "forward:/meeting/list";
+    }
+}

--- a/src/main/java/com/zpop/web/controller/MeetingController.java
+++ b/src/main/java/com/zpop/web/controller/MeetingController.java
@@ -15,7 +15,12 @@ public class MeetingController {
 	}
 
 	@GetMapping("/{id}")
-	public String detailView() {
+	public String detailView() { // Model model
+		// 개발 테스트용 
+		// model.addAttribute("tempMember", 1);
+		// model.addAttribute("isMine", false);
+
+		// return "meeting/detail-imple";
 		return "meeting/detail";
 	}
 }

--- a/src/main/resources/static/css/member/component/meeting-info.css
+++ b/src/main/resources/static/css/member/component/meeting-info.css
@@ -15,6 +15,7 @@
 
 .meeting__title-hambuger-icon{
     margin-left: auto;
+    cursor: pointer;
 }
 
 .meeting__category{
@@ -74,15 +75,14 @@
 }
 
 .meeting__btn {
-    display: inline-flex;
+    display: block;
     position: fixed;
-    bottom: 0px;
+    bottom: 8px;
     font-size: 16px;
-    
 }
+
 .btn-join{
     width: 90vw;
-   
 }
 
 

--- a/src/main/resources/templates/inc/select-modal.html
+++ b/src/main/resources/templates/inc/select-modal.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" 
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+    <!--💛글상세보기, 주최자-->
+    <div th:fragment="meeting-host" class="modal-select" id="meeting__article-tool">
+        <div class="modal-select__contents">복사 하기
+            <span class="icon icon-copy"></span>
+        </div>
+        <div class="modal-select__contents">수정
+            <span class="icon icon-edit"></span>
+        </div>
+        <div class="modal-select__contents">삭제
+            <span class="icon icon-trash"></span>
+        </div>
+    </div>
+
+    <!--💛글상세보기, 참여자-->
+    <div th:fragment="meeting-participant" class="modal-select" id="meeting__article-tool">
+        <div class="modal-select__contents">복사하기
+            <span class="icon icon-copy"></span>
+        </div>
+        <div class="modal-select__contents">참여링크
+            <span class="icon icon-link"></span>
+        </div>
+        <div class="modal-select__contents">글 신고
+            <span class="icon icon-siren-red"></span>
+        </div>
+    </div>
+
+    
+    <!--💛글상세보기, 기본유저-->
+    <div th:fragment="meeting-anonymous" class="modal-select" id="meeting__article-tool">
+        <div class="modal-select__contents">복사 하기
+            <span class="icon icon-copy"></span>
+        </div>
+        <div class="modal-select__contents">글 신고
+            <span class="icon icon-siren-red"></span>
+        </div>
+    </div>
+</html>

--- a/src/main/resources/templates/meeting/detail-imple.html
+++ b/src/main/resources/templates/meeting/detail-imple.html
@@ -1,0 +1,140 @@
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{inc/layout}">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/css/member/component/profile-box.css" type="text/css">
+    <link rel="stylesheet" href="/css/member/component/meeting-info.css" type="text/css">
+    <link rel="stylesheet" href="/css/member/component/participant.css" type="text/css" >
+    <link rel="stylesheet" href="/css/member/component/comment.css" type="text/css"/>
+    <!-- detail page css -->
+    <link rel="stylesheet" href="/css/member/meeting/detail.css">
+</head>
+<body>
+<main layout:fragment="content" class="main">
+    <section class="meeting">
+        <div class="meeting__info">
+            <div class="meeting__category-wrap">
+                <span class="meeting__category">문화생활</span>
+            </div>
+            <div class="meeting__header">
+                <div class="meeting__title-container">
+                    <span class="meeting__title">한강공원에서 러닝하실 분~🙂</span>
+                    <img data-modal="#meeting__article-tool" class="meeting__title-hambuger-icon" src="/images/icon/hambuger.svg">
+                    <!-- TODO : CSS -->
+                    <th:block th:if="${tempMember}">
+                        <div th:replace="~{inc/select-modal::${isMine}==true?'meeting-host':'meeting-participant'}"></div>
+                    </th:block>
+                    <block th:unless="${tempMember}" >
+                        <div th:replace="inc/select-modal :: meeting-anonymous"></div>
+                    </block>
+                </div>
+                <div class="meeting__date-container">
+                    <img class="meeting__small-calander" src="/images/icon/small-calander.svg">
+                    <span class="meeting__date">11.01(일) 13:00</span>
+                </div>
+                <div class="meeting__region-container">
+                    <img class="meeting__small-location" src="/images/icon/small-location.svg" alt="">
+                    <span class="meeting__region">경남/부산/울산</span>
+                </div>
+                <div class="meeting__detail-region-wrap">
+                    <span class="meeting__detail-region">서면역 9와 3/4 이번에도 수정하면 꿀밤 날리겠습니다^^</span>
+                </div>
+            </div>
+        </div>
+        <div class="meeting__conetent-container">
+                    <span class="meeting__content">
+                        한강에서 우리 함께 뛰어요~!
+                        왜냐면은 제가 달리기를너무너무 조아하하하하해하기때문이에용
+                        목표는 10km! 완주하실 분만 모집합니다~!!
+                        날씨는 좋을 예정이네요~
+                        그래도 물을 충분히 가져오시는게 좋옹아아아요~!
+                    </span>
+            <div class="meeting__tags">
+                #20대 선호
+                #+10명
+                #남자만
+            </div>
+            <div class="meeting__views">조회수 999회</div>
+            <div class="meeting__btn">
+                <span class="btn btn-round btn-action btn-join">참여하기</span>
+            </div>
+        </div>
+        </div>
+    </section>
+
+    <section class="participant">
+        <div class="participant__num">
+            <span>참가자</span>
+            <span>15/56</span>
+            <span class="icon icon-arrow-up"></span>
+        </div>
+        <ul class="participant__list">
+            <li>
+                <span class="participant__info"><img src="/images/girl.svg">일이삼사오육칠팔구십</span>
+            </li>
+            <li>
+                <span class="participant__info"><img src="/images/girl.svg">일이삼사오육칠팔구십</span>
+            </li>
+            <li>
+                <span class="participant__info"><img src="/images/girl.svg">일이삼사오육칠팔구십</span>
+            </li>
+            <li>
+                <span class="participant__info"><img src="/images/girl.svg">일이삼사오육칠팔구십</span>
+            </li>
+            <li>
+                <span class="participant__info"><img src="/images/girl.svg">일이삼사오육칠팔구십</span>
+            </li>
+        </ul>
+    </section>
+
+    <section class="comment">
+        <h2 class="comment__num">댓글 N개</h2>
+        <div class="comment__input-container">
+                <textarea
+                        class="comment__input"
+                        name="댓글 입력"
+                        placeholder="댓글을 입력하세요."
+                ></textarea>
+            <span class="comment__btn btn btn-round btn-action">등록하기</span>
+        </div>
+        <ul class="comment__list">
+            <li>
+                <div class="profile">
+                    <span class="profile__image"></span>
+                    <span class="profile__nickname">찬우몬</span>
+                    <span class="profile__time">3분전</span>
+                    <button></button>
+                </div>
+                <span class="comment__content">
+                        이 헌법에 의한 최초의 대통령의 임기는 이 헌법시행일로부터 개시한다. 모든 국민은 거주·이전의 자유를 가진다. 대통령은 제1항과 제2항의 처분 또는 명령을 한 때에는 지체없이 국회에 보고하여 그 승인을 얻어야 한다.
+                    </span>
+                <div class="comment__replies">
+                    <span>답글 n개</span>
+                    <span>답글 달기</span>
+                </div>
+            </li>
+        </ul>
+    </section>
+    </div>
+
+    <!-- 💚 댓글 (작성자)-->
+    <div class="modal-select">
+        <div class="modal-select__contents">수정
+            <span class="icon icon-edit"></span>
+        </div>
+        <div class="modal-select__contents">삭제
+            <span class="icon icon-trash"></span>
+        </div>
+    </div>
+
+    <!-- 💚 댓글 (기본유저)-->
+    <div class="modal-select">
+
+        <div class="modal-select__contents">댓글 신고
+            <span class="icon icon-siren-red"></span>
+        </div>
+    </div>
+
+
+    <!--------------------------  케밥 모달 추가 --------------------------->
+</body>
+</html>


### PR DESCRIPTION
## 작업사항
1. 모임 상세보기의 케밥 모달 임시 구현.
추후 상세보기 페이지 요청되면 합치기
[refactor: meeting select modal](https://github.com/Z-P0P/ZPOP/commit/cdf9f68be357a9e0c2ba2fc7efa966f77cf24f2c)
2. 모임 상세보기의 제목 옆 케밥 아이콘에 cursor 옵션 추가
3. root 경로 -> 모임 리스트 forward 추가