### PR TITLE
feat: 모임 참여자 강퇴하기에 탈퇴 회원 예외처리

### DIFF
--- a/src/main/java/com/zpop/web/dao/ParticipationDao.java
+++ b/src/main/java/com/zpop/web/dao/ParticipationDao.java
@@ -20,6 +20,7 @@ public interface ParticipationDao {
     List<MeetingParticipantsDto>getByMeetingId(int meetingId);
     List<AdminParticipationDto> getAdminViewList(int size, int offset, String keyword, String option);
     int updateBannedAt(int id);
+    int updateCanceledAt(int id);
 	int countBySearch(String keyword, String option);
 	
 	int[] getParticipantIdByMeetingId(int meetingId);

--- a/src/main/java/com/zpop/web/entity/Member.java
+++ b/src/main/java/com/zpop/web/entity/Member.java
@@ -1,6 +1,6 @@
 package com.zpop.web.entity;
 
-import java.sql.Date;
+import java.util.Date;
 
 public class Member {
     private int id;

--- a/src/main/java/com/zpop/web/service/DefaultMeetingService.java
+++ b/src/main/java/com/zpop/web/service/DefaultMeetingService.java
@@ -305,11 +305,12 @@ public class DefaultMeetingService implements MeetingService {
 		if (kickTarget.getBannedAt() != null)
 			throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 강퇴된 회원입니다");
 
-		// 탈퇴한 회원인지 확인
+		// 탈퇴한 회원인지 확인 후
+		// 탈퇴한 회원이라면 참여 취소처리한다.
 		int kickTargetMemberId = kickTarget.getParticipantId();
 		Member kickTargetMember = memberDao.getById(kickTargetMemberId);
 		if (kickTargetMember.getResignedAt() != null) {
-			// TODO: dao.참여취소(kickTargetId);
+			participationDao.updateCanceledAt(kickTargetMemberId);
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다");
 		}
 

--- a/src/main/resources/mapper/ParticipationDaoMapper.xml
+++ b/src/main/resources/mapper/ParticipationDaoMapper.xml
@@ -51,6 +51,12 @@
 		WHERE id=#{id}
 	</update>
 
+	<update id="updateCanceledAt">
+		UPDATE participation
+		SET canceledAt = CURRENT_TIMESTAMP()
+		WHERE id=#{id}
+	</update>
+
 	<select id="countBySearch" resultType= "java.lang.Integer">
       	SELECT COUNT(id) 
       	FROM participation

--- a/src/test/java/com/zpop/web/service/DefaultMeetingServiceTest.java
+++ b/src/test/java/com/zpop/web/service/DefaultMeetingServiceTest.java
@@ -430,7 +430,40 @@ class DefaultMeetingServiceTest {
         assertThat(e.getReason()).isEqualTo("이미 강퇴된 회원입니다");
     }
 
-    // TODO: 탈퇴한 회원 테스트
+    @Test
+    public void kick_탈퇴한_회원이라면_참여취소_처리_후_NOT_FOUND() {
+        //given
+        int meetingId = 1;
+        int participantId = 1;
+        Member member = new Member();
+        member.setId(1);
+
+        Meeting meeting = new Meeting();
+        meeting.setId(1);
+        meeting.setRegMemberId(1);
+
+        Participation resignedParticipation = new Participation();
+        resignedParticipation.setParticipantId(1);
+        List<Participation> list = new ArrayList<>();
+        list.add(resignedParticipation);
+
+        Member resigendMember = new Member();
+        resigendMember.setId(999);
+        resigendMember.setResignedAt(new Date());
+
+        // mocking
+        given(dao.get(anyInt())).willReturn(meeting);
+        given(participationDao.getListByMeetingId(anyInt())).willReturn(list);
+        given(memberDao.getById(anyInt())).willReturn(resigendMember);
+
+        //when
+        ResponseStatusException e = assertThrows(ResponseStatusException.class,
+                () -> service.kick(meetingId, participantId, member));
+
+        //then
+        assertThat(e.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(e.getReason()).isEqualTo("존재하지 않는 회원입니다");
+    }
 
     @Test
     public void kick_자신을_강퇴한다면_BAD_REQUEST() {


### PR DESCRIPTION
## 🛠 작업사항
- 참여자 강퇴에 TODO로 남겨둔 `강퇴할 참여자가 탈퇴한 회원인지 확인후, 탈퇴한 회원이라면 모임 취소 처리후 예외를 던진다` 추가
- 윗 내용 테스트 코드 추가
- 브랜치 병합중 삭제된 코드 복구
- Member Entity Date 타입 수정
