### PR TITLE
refactor: 모임 리스트 조회 - 모임 시작 시간과 관련한 로직 수정

### DIFF
--- a/src/main/java/com/zpop/web/service/DefaultMeetingService.java
+++ b/src/main/java/com/zpop/web/service/DefaultMeetingService.java
@@ -43,22 +43,6 @@ import com.zpop.web.entity.meeting.Meeting;
 import com.zpop.web.entity.meeting.MeetingThumbnailView;
 import com.zpop.web.utils.TextDateTimeCalculator;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-
-import com.zpop.web.dao.CategoryDao;
-
-import com.zpop.web.dto.MeetingDetailDto;
-import com.zpop.web.dto.MeetingParticipantsDto;
-
-
 @Service
 public class DefaultMeetingService implements MeetingService {
 
@@ -99,12 +83,13 @@ public class DefaultMeetingService implements MeetingService {
 	@Override
 	public List<MeetingThumbnailResponse> getList(int startId, String keyword, Integer categoryId, String strRegionIds,
 			Boolean isClosed) {
+
 		String[] regionIds = null;
 		if (strRegionIds != null)
 			regionIds = strRegionIds.split(",");
 
-		MeetingThumbnailPagination pagination = new MeetingThumbnailPagination(startId, keyword, categoryId, regionIds,
-				isClosed);
+		MeetingThumbnailPagination pagination = new MeetingThumbnailPagination(
+			startId, keyword, categoryId, regionIds, isClosed);
 
 		List<MeetingThumbnailView> meetingThumbnailViews = dao.getThumbnailViewList(pagination);
 
@@ -113,23 +98,26 @@ public class DefaultMeetingService implements MeetingService {
 		for (MeetingThumbnailView m : meetingThumbnailViews) {
 			String genderCategory = "누구나";
 			switch (m.getGenderCategory()) {
-			case 1:
-				genderCategory = "남자 모임";
-				break;
-			case 2:
-				genderCategory = "여자 모임";
-				break;
+				case 1:
+					genderCategory = "남자 모임";
+					break;
+				case 2:
+					genderCategory = "여자 모임";
+					break;
 			}
 
 			String dateTime = TextDateTimeCalculator.getTextDateTime(m.getStartedAt());
 
+			// 마감되었거나 시작 일시가 지났다면 isClosed는 true로 응답한다
 			boolean isClosedResult = false;
-			if (m.getClosedAt() != null)
+			Date currentTime = new Date();
+
+			if (m.getClosedAt() != null || m.getStartedAt().before(currentTime))
 				isClosedResult = true;
 
 			MeetingThumbnailResponse meetingThumbnail = new MeetingThumbnailResponse(m.getId(), m.getCategory(),
-					m.getRegion(), m.getAgeRange(), genderCategory, m.getMaxMember(), m.getTitle(), dateTime,
-					m.getViewCount(), m.getCommentCount(), isClosedResult);
+				m.getRegion(), m.getAgeRange(), genderCategory, m.getMaxMember(), m.getTitle(), dateTime,
+				m.getViewCount(), m.getCommentCount(), isClosedResult);
 
 			list.add(meetingThumbnail);
 		}

--- a/src/main/resources/mapper/MeetingDaoMapper.xml
+++ b/src/main/resources/mapper/MeetingDaoMapper.xml
@@ -2,20 +2,20 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.zpop.web.dao.MeetingDao">
 	<select id="getDetailView"  resultType= "com.zpop.web.dto.MeetingDetailDto">
-        SELECT m.title, m.startedAt, m.detailRegion, m.content, m.maxMember, m.regMemberId,m.id,
-                        m.viewCount,c.name categoryName, r.name regionName
-        FROM meeting m 
-        JOIN category c on m.categoryId = c.id 
-        JOIN region r on m.regionId = r.id 
-        WHERE m.id = #{id};
+		SELECT m.title, m.startedAt, m.detailRegion, m.content, m.maxMember, m.regMemberId,m.id,
+										m.viewCount,c.name categoryName, r.name regionName
+		FROM meeting m
+		JOIN category c on m.categoryId = c.id
+		JOIN region r on m.regionId = r.id
+		WHERE m.id = #{id};
 	</select>
 
-	<insert id="insert" parameterType="Meeting" useGeneratedKeys="true" keyProperty="id">        
+	<insert id="insert" parameterType="Meeting" useGeneratedKeys="true" keyProperty="id">
 		INSERT INTO meeting
-        (regMemberId, categoryId, regionId, ageRangeId, title, content, detailRegion, maxMember,
-        startedAt, contact, contactTypeId , genderCategory)
-        VALUES (#{regMemberId}, #{categoryId}, #{regionId}, #{ageRangeId},
-        #{title}, #{content}, #{detailRegion}, #{maxMember}, #{startedAt}, #{contact}, #{contactTypeId}, #{genderCategory})
+			(regMemberId, categoryId, regionId, ageRangeId, title, content, detailRegion, maxMember,
+			startedAt, contact, contactTypeId , genderCategory)
+		VALUES (#{regMemberId}, #{categoryId}, #{regionId}, #{ageRangeId},
+			#{title}, #{content}, #{detailRegion}, #{maxMember}, #{startedAt}, #{contact}, #{contactTypeId}, #{genderCategory})
     </insert>
     
     <update id="updateContent" parameterType="Meeting">
@@ -32,36 +32,38 @@
 
     <select id="getThumbnailViewList" parameterType="com.zpop.web.dto.MeetingThumbnailPagination"
         resultType="com.zpop.web.entity.meeting.MeetingThumbnailView">
-        SELECT * FROM meetingThumbnail <trim
-            prefix="WHERE" prefixOverrides="AND | OR">
-            <choose>
-                <when test="startId == 0"> id >= #{startId} </when>
-                <otherwise>
-                    <![CDATA[ id < #{startId} ]]>
-                </otherwise>
-            </choose>
-            <choose>
-                <when test="isClosed == false"> 
-                    AND closedAt IS NULL
-                </when>
-                <when test="isClosed == true"> 
-                    AND closedAt IS NOT NULL
-                </when>
-            </choose>
-            <if test="categoryId != null">
-                AND categoryId = #{categoryId}
-            </if>
-            <if test="regionIds != null">
-                AND regionId IN 
-                <foreach collection="regionIds" item="regionId" separator="," open="(" close=")">
-                    #{regionId}
-                </foreach>
-            </if>
-            <if test="keyword !=null">
-                AND title LIKE '%${keyword}%'
-            </if>
+        SELECT * FROM meetingThumbnail
+		<trim prefix="WHERE" prefixOverrides="AND | OR">
+			<choose>
+				<when test="startId == 0"> id >= #{startId} </when>
+					<otherwise>
+						<![CDATA[ id < #{startId} ]]>
+					</otherwise>
+			</choose>
+			<choose>
+				<when test="isClosed == false">
+					AND closedAt IS NULL
+					<![CDATA[ AND startedAt >= NOW() ]]>
+				</when>
+				<when test="isClosed == true">
+					AND closedAt IS NOT NULL
+				</when>
+			</choose>
+			<if test="categoryId != null">
+				AND categoryId = #{categoryId}
+			</if>
+			<if test="regionIds != null">
+				AND regionId IN
+				<foreach collection="regionIds" item="regionId" separator="," open="(" close=")">
+					#{regionId}
+				</foreach>
+			</if>
+			<if test="keyword !=null">
+				AND title LIKE '%${keyword}%'
+			</if>
         </trim>
-        LIMIT 0, 9; </select>
+        LIMIT 0, 9; 
+	</select>
 
     <update id="updateDeletedAt" parameterType="com.zpop.web.entity.meeting.Meeting"> 
         UPDATE meeting
@@ -76,9 +78,9 @@
     </update>
 	
 	<update id="updateViewCount" parameterType="com.zpop.web.dto.MeetingDetailDto">
-        UPDATE meeting
-        SET viewCount = viewCount + 1
-        WHERE id = #{id}
+				UPDATE meeting
+				SET viewCount = viewCount + 1
+				WHERE id = #{id}
 	</update>
 
 	<select id="getMeetingList"
@@ -91,6 +93,7 @@
 		WHERE m.id
 		=#{id}
 	</select>
+
 	<select id="getAdminViewList" resultType="AdminMeetingDto">
 		SELECT
 		meeting.id,


### PR DESCRIPTION
* 모임 조회에 startedAt 옵션 추가하여 응답. 모임시작 시간이 지났으나 마감처리되지 않은 글을 모집 완료로 응답하기 위해서 추가함

## 🛠 작업사항
- 불필요 코드 삭제
- 모임 리스트 조회시 다음과 같은 문제가 있어서 수정
- 모임 시작 시간 `startedAt`이 지났으나, 마감 시간`closedAt`이 업데이트 되지 않아서
  시작 시간이 지난 모임도 사용자에게 `모집중`으로 응답하고 있었음
### 수정 전
```xml
    <choose>
        <when test="isClosed == false"> 
            AND closedAt IS NULL
        </when>
        <when test="isClosed == true"> 
            AND closedAt IS NOT NULL
        </when>
    </choose>
```

```java
if (m.getClosedAt() != null )
  isClosedResult = true;
```
### 수정 후
- SQL은 "마감여부"가 `false`라면, `closedAt`이 null이고, `startedAt`이 현재 시각보다 미래인 것을 조회
```xml
    <choose>
        <when test="isClosed == false">
	        AND closedAt IS NULL
	        <![CDATA[ AND startedAt >= NOW() ]]>
        </when>
        <when test="isClosed == true">
	        AND closedAt IS NOT NULL
        </when>
    </choose>
```
- 모임 시작시간이 지났으나 UPDATE 되지 않아 `closedAt`이 null인 데이터가 있을 수 있음.
- 따라서 가져온 view entity의 `startedAt`이 현재보다 과거라면 `isClosedResult = true` 추가
```java
if (m.getClosedAt() != null || m.getStartedAt().before(currentTime))
  isClosedResult = true;
```
## 💡 기타
- 모임 상세 조회에 시작 시간 지난 모임 UPDATE 필요
