### PR TITLE
fix: 헤더 셀렉트 모달 수정

### DIFF
--- a/src/main/resources/static/css/member/component/header.css
+++ b/src/main/resources/static/css/member/component/header.css
@@ -194,6 +194,7 @@
 }
 
 .header__profile .select-box__options--header a{
+  display: inline-block;
 	width:100%;
 }
 

--- a/src/main/resources/static/css/member/component/select.css
+++ b/src/main/resources/static/css/member/component/select.css
@@ -85,8 +85,13 @@
 }
 
 .select-box__options--header > li {
+  padding: 0;
+}
+
+.select-box__options--header > li > a{
   padding: 10px 15px;
 }
+
 
 .select-box__options > li:hover {
   background-color: var(--main-color);

--- a/src/main/resources/static/js/meeting/list/list.js
+++ b/src/main/resources/static/js/meeting/list/list.js
@@ -17,7 +17,7 @@ window.addEventListener("load", function () {
   }
 
   // 지역
-  const regions = document.querySelectorAll(".select-box__options > li");
+  const regions = document.querySelectorAll(".region-category .select-box__options > li");
   for (const region of regions) {
     region.onclick = onClickRegion;
   }

--- a/src/main/resources/templates/inc/header.html
+++ b/src/main/resources/templates/inc/header.html
@@ -84,11 +84,11 @@
 <!--                    th:src="@{(${session.member.profileImagePath}?${session.member.profileImagePath}:'/images/icon/user-profile.svg')}"></button>-->
                     <ul class="select-box__options select-box__options--right select-box__options--header">
                         <!--li 말고 div 박스 전체로 -->
-                        <li onclick="location.href='/member/me';"><a href="/member/me">내 프로필</a></li>
-                        <li onclick="location.href='/member/me/gathering';"><a href="/member/me/gathering">내가 모집한 모임</a></li>
+                        <li><a href="/member/me">내 프로필</a></li>
+                        <li><a href="/member/me/gathering">내가 모집한 모임</a></li>
                         <li><a href="/member/me/meeting">내가 참여한 모임</a></li>
                         <li><a href="/member/me/meeting">모임 평가하기</a> </li>
-                        <li onclick="location.href='/logout';"><a href="">로그아웃</a></li>
+                        <li><a href="/logout">로그아웃</a></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
## 🛠 작업사항
- 헤더 프로필 선택모달 클릭 시 해당 텍스트가 지역 옵션 선택한 것으로 들어가는 버그 수정함
- 헤더 프로필 선택모달 클릭 범위가 텍스트 영역으로 국한되는 문제 수정함

### 수정 전
- 로그인 후 헤더 프로필 클릭 시 나타나는 선택창 모달 클릭 영역이 택스트로 국한되는 문제가 있었음
- 메인 모임글 조회 화면에서, 로그인 후 헤더 프로필 클릭 시 나타나는 선택창 모달 클릭 시 해당 내용이 지역카테고리 선택 아이콘으로 들어가는 버그가 있었음 

### 수정 후
- 인라인 js 코드 삭제
- a태그 크기를 키워서 링크이동 가능하게 바꿈
- 이전에 보니 인라인 자바스크립트 코드로 해결을 한 것 같으나, 아무래도 a 태그 써먹는게 좋을 것 같아 수정함
(다른 페이지 헤더 보니 인라인 자바스크립트 코드 안들어가있어서 어쩄든 수정해야 했음)
- querySelector 수정
