### PR TITLE
refactor: 모임 참여자 목록 얻기 개선

### DIFF
--- a/src/main/java/com/zpop/web/controller/MeetingController.java
+++ b/src/main/java/com/zpop/web/controller/MeetingController.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.zpop.web.dto.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,13 +26,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.zpop.web.dto.MeetingDetailResponse;
-import com.zpop.web.dto.MeetingParticipantsDto;
-import com.zpop.web.dto.RegisterMeetingRequest;
-import com.zpop.web.dto.RegisterMeetingResponse;
-import com.zpop.web.dto.RegisterMeetingViewResponse;
-import com.zpop.web.dto.UpdateMeetingRequest;
-import com.zpop.web.dto.UpdateMeetingViewDto;
 import com.zpop.web.security.ZpopUserDetails;
 import com.zpop.web.service.CommentService;
 import com.zpop.web.service.MeetingService;
@@ -140,8 +134,8 @@ public class MeetingController {
 	//참여자목록 AJAX endpoint(js가 콜하는 함수)
 	@GetMapping("{meetingId}/participant")
 	@ResponseBody
-	public List<MeetingParticipantsDto> getParticipant(@PathVariable int meetingId){
-		List<MeetingParticipantsDto> list = service.getParticipants(meetingId);
+	public List<ParticipantResponse> getParticipant(@PathVariable int meetingId){
+		List<ParticipantResponse> list = service.getParticipants(meetingId);
 		return list;
 	}
 	

--- a/src/main/java/com/zpop/web/service/DefaultMeetingService.java
+++ b/src/main/java/com/zpop/web/service/DefaultMeetingService.java
@@ -236,7 +236,6 @@ public class DefaultMeetingService implements MeetingService {
 		 * 댓글 정보 조회 및 가공
 		 */ 
 		List<CommentView> comments = commentDao.getComment(id);
-		int commentCount = commentDao.getCountOfComment(id);
 
 		List<CommentResponse> commentsResponse = new ArrayList<>();
 
@@ -281,7 +280,7 @@ public class DefaultMeetingService implements MeetingService {
 			ageRange.getType(),
 			meeting.getRegMemberId(),
 			meeting.getViewCount(),
-			commentCount,
+			meeting.getCommentCount(),
 			isMyMeeting,
 			hasParticipated,
 			isClosed,

--- a/src/main/java/com/zpop/web/service/DefaultMeetingService.java
+++ b/src/main/java/com/zpop/web/service/DefaultMeetingService.java
@@ -597,9 +597,26 @@ public class DefaultMeetingService implements MeetingService {
 	}
 
 	@Override
-	public List<MeetingParticipantsDto> getParticipants(int id) {
-		// TODO Auto-generated method stub
-		return null;
+	public List<ParticipantResponse> getParticipants(int id) {
+		Meeting meeting = dao.get(id);
+		if (meeting == null) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "모임이 없습니다");
+		}
+
+		List<ParticipationInfoView> list = participationDao.getParticipantInfoByMeetingId(id);
+		List<ParticipantResponse> participants = new ArrayList<>();
+
+		for (ParticipationInfoView p : list) {
+			// 취소 or 내보낸 당한 참여자는 스킵
+			if(p.getCanceledAt() != null || p.getBannedAt() !=null)
+				continue;
+
+			ParticipantResponse participant =
+					new ParticipantResponse(p.getId(), p.getNickname(), p.getProfileImagePath());
+			participants.add(participant);
+		}
+
+		return participants;
 	}
 
 	private void createNotification(int memberId, String url, int type) {

--- a/src/main/java/com/zpop/web/service/MeetingService.java
+++ b/src/main/java/com/zpop/web/service/MeetingService.java
@@ -57,7 +57,16 @@ public interface MeetingService {
 	 */
 	MeetingDetailResponse getById(int id, Integer memberId);
 
-	List<MeetingParticipantsDto> getParticipants(int id);
+	/**
+	 * 참여자 목록 조회하기.
+	 *
+	 * 해당 id의 모임의 참여자 목록을 조회한다.
+	 * 존재하지 않는 id의 모임이면 조회할 수 없다.
+	 *
+	 * @param id
+	 * @return 참여자 목록
+	 */
+	List<ParticipantResponse> getParticipants(int id);
 
 	/**
 	 * 모임 연락처 얻기.


### PR DESCRIPTION
## 🛠 작업사항
- 모임 참여자 목록 얻기에 대한 개선
  - 메서드에 대한 주석 추가
  - `commentCount`를 DAO를 통해 조회하는게 아닌 `Meeting` 엔티티에서 commentCount getter를 사용하는 것으로 수정