### PR TITLE
fix: 모임 상세조회 모달 겹쳐지는 문제

### DIFF
--- a/src/main/resources/static/css/deco.css
+++ b/src/main/resources/static/css/deco.css
@@ -10,6 +10,18 @@
 	visibility:hidden !important;
 }
 
+.z-idx-1 {
+  z-index: 100;
+}
+
+.z-idx-2 {
+  z-index: 200;
+}
+
+.z-idx-3 {
+  z-index: 300;
+}
+
 .pointer{
 	cursor:pointer
 }

--- a/src/main/resources/templates/inc/meeting-detail-modal.html
+++ b/src/main/resources/templates/inc/meeting-detail-modal.html
@@ -3,7 +3,7 @@
 	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 
     <!--💛글상세보기, 참여자-->
-    <div class="modal-select"  th:fragment="member-participant">
+    <div class="modal-select z-idx-1"  th:fragment="member-participant">
         <div class="modal-select__contents">복사하기
             <span class="icon icon-copy"></span>
         </div>
@@ -17,7 +17,7 @@
     <!--💛글상세보기, 주최자-->
 
 
-    <div class="modal-select" th:fragment="member-host">
+    <div class="modal-select z-idx-1" th:fragment="member-host">
         <div class="modal-select__contents">복사 하기
             <span class="icon icon-copy"></span>
         </div>
@@ -30,7 +30,7 @@
     </div>
 
     <!--💛글상세보기, 기본유저-->
-    <div class="modal-select" th:fragment="member">
+    <div class="modal-select z-idx-1" th:fragment="member">
         <div class="modal-select__contents">복사 하기
             <span class="icon icon-copy"></span>
         </div>
@@ -41,7 +41,7 @@
 
 
     <!-- 💚 댓글 (작성자)-->
-    <div class="modal-select comment__kebob" th:fragment="writer">
+    <div class="modal-select comment__kebob z-idx-1" th:fragment="writer">
         <div class="modal-select__contents" data-id="comment-edit">수정
             <span class="icon icon-edit"></span>
         </div>
@@ -51,9 +51,9 @@
     </div>
 
     <!-- 💚 댓글 (기본유저)-->
-    <div class="modal-select comment__kebob" th:fragment="reader">
+    <div class="modal-select comment__kebob z-idx-1" th:fragment="reader">
 
-        <div class="modal-select__contents modal__on-btn" data-id="comment-report" data-modal="#modal-report-comment">댓글 신고
+        <div class="modal-select__contents modal__on-btn " data-id="comment-report" data-modal="#modal-report-comment">댓글 신고
             <span class="icon icon-siren-red"></span>
         </div>
     </div>

--- a/src/main/resources/templates/meeting/detail.html
+++ b/src/main/resources/templates/meeting/detail.html
@@ -70,7 +70,7 @@
                 <span th:text="|#${meeting.genderCategory}|">성별</span>
             </div>
             <div class="meeting__views"  th:text="|조회수${meeting.viewCount}|">조회수</div>
-            <div class="meeting__btn">
+            <div class="meeting__btn z-idx-2">
                 <span th:if="${meeting.isClosed == true}" class="btn btn-round btn-join btn-cancel">모집완료</span>
                 <span th:unless="${meeting.isClosed == true}" th:if="${meeting.isMyMeeting == true}" class="btn btn-round btn-join btn-action modal__on-btn" id="btn-close" data-modal="#modal-wrapper-close">마감하기</span>
                 <span th:unless="${meeting.isClosed == true}" th:if="${meeting.isMyMeeting == false and meeting.hasParticipated == false} " class="btn btn-round btn-join btn-action modal__on-btn" id="participation-btn"  data-modal="#modal-wrapper-participation">참여하기</span>
@@ -100,7 +100,7 @@
     </section>
 			
    <!------ 참여 모달 ------>
-     <div class="modal-2 hidden" id="modal-wrapper-participation">
+     <div class="modal-2 hidden z-idx-1" id="modal-wrapper-participation">
 
         <div class="modal-participation">
             <div class="modal__header">
@@ -126,7 +126,7 @@
         </div>
     </div>
     <!-- -------------모임 마감 모달----------------------->
-    	<div class="popup-container modal-wrapper hidden" id="modal-wrapper-close">
+    	<div class="popup-container modal-wrapper hidden z-idx-1" id="modal-wrapper-close">
 		<div class="popup__wrap-inactive" id="popup">
 			<div class="popup">
 				<div class="popup__body">
@@ -144,7 +144,7 @@
 		</div>
 	</div>
     <!--------------- 모임 신고 모달----------------------->
-    <div id="modal-report-meeting" class="modal-wrapper hidden">
+    <div id="modal-report-meeting" class="modal-wrapper hidden z-idx-1">
       <div class="modal">
         <div class="modal__header">
     
@@ -178,7 +178,7 @@
       </div>
     </div>
     <!--------------- 댓글 신고 모달 -------------------->
-     <div id="modal-report-comment" class="modal-wrapper hidden">
+     <div id="modal-report-comment" class="modal-wrapper hidden z-idx-1">
       <div class="modal">
         <div class="modal__header">
     
@@ -212,7 +212,7 @@
     </div>
     
     <!--------------- 사용자 신고 모달 -------------------->
-      <div id="modal-report-member" class="modal-wrapper hidden">
+      <div id="modal-report-member" class="modal-wrapper hidden z-idx-1">
       <div class="modal">
         <div class="modal__header">
             <span class="modal__close-btn icon icon-x" data-modal="#modal-report-member">닫기</span>


### PR DESCRIPTION
## 🛠 작업사항
- 모임 상세조회 view에서 모달, 버튼들이 겹쳐지는 문제를 해결 함
- deco.css에 다음 추가
```css

.z-idx-1 {
  z-index: 100;
}

.z-idx-2 {
  z-index: 200;
}

.z-idx-3 {
  z-index: 300;
}
```
