### PR TITLE
hotfix for comment count

### DIFF
--- a/src/main/java/com/zpop/web/controller/ReplyController.java
+++ b/src/main/java/com/zpop/web/controller/ReplyController.java
@@ -59,11 +59,11 @@ public class ReplyController {
 	//답글(reply) 등록 AJAX endpoint (js에서 콜하는 함수)
 	@PostMapping()
 	@ResponseBody
-	public  String registerReply(@RequestBody Comment reply, 
+	public  boolean registerReply(@RequestBody Comment reply, 
 			@AuthenticationPrincipal ZpopUserDetails userDetails) {
 		reply.setWriterId(userDetails.getId());
 		service.registerReply(reply);
-		return "{\"1\":1}"; //JSON
+		return true;
 	}
 	//댓글 수정 AJAX endpoint
 	@PatchMapping("{id}")
@@ -86,12 +86,12 @@ public class ReplyController {
 	//댓글 신고 AJAX endpoint
 	@PutMapping("{id}")
 	@ResponseBody
-	public String reportReply(@PathVariable int id, @RequestBody ReportedComment reportedReply,
+	public boolean reportReply(@PathVariable int id, @RequestBody ReportedComment reportedReply,
 			@AuthenticationPrincipal ZpopUserDetails userDetails) {
 		Comment reply = service.getCommentById(id);
 		reportedReply.setReporterId(userDetails.getId());
 		reportedReply.setOriginal(reply.getContent());
 		reportService.createCommentReport(reportedReply);
-		return "{\"1\":1}"; //JSON
+		return true; 
 	}
 }

--- a/src/main/java/com/zpop/web/service/DefaultCommentService.java
+++ b/src/main/java/com/zpop/web/service/DefaultCommentService.java
@@ -107,7 +107,7 @@ public class DefaultCommentService implements CommentService {
 	public int registerReply(Comment comment) {
 		int affectedRow = dao.insertReply(comment);
 
-		meetingDao.increaseCommentCount(comment.getMeetingId());
+		//meetingDao.increaseCommentCount(comment.getMeetingId());
 
 		int commentId = comment.getParentCommentId();
 		Comment parentComment = dao.getCommentById(commentId);

--- a/src/main/java/com/zpop/web/service/DefaultCommentService.java
+++ b/src/main/java/com/zpop/web/service/DefaultCommentService.java
@@ -166,7 +166,8 @@ public class DefaultCommentService implements CommentService {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다");
 		
 		// 모임 댓글 수 감소
-		meetingDao.decreaseCommentCount(comment.getMeetingId());
+		if(comment.getGroupId()==0) //답글이 아닌 댓글인 경우만 미팅테이블의 댓글카운트 감소
+			meetingDao.decreaseCommentCount(comment.getMeetingId());
 		
 		return affectedRow;
 	}

--- a/src/main/java/com/zpop/web/service/DefaultMeetingService.java
+++ b/src/main/java/com/zpop/web/service/DefaultMeetingService.java
@@ -224,7 +224,8 @@ public class DefaultMeetingService implements MeetingService {
 			// 내가 참여한 모임인지 확인
 			if(memberId != null && p.getParticipantId() == memberId)
 				hasParticipated = true;
-
+			if(p.getCanceledAt() != null || p.getBannedAt() != null)
+				continue;
 			participationsResponse.add(new ParticipantResponse(
 				p.getId(),
 				p.getNickname(),
@@ -607,7 +608,7 @@ public class DefaultMeetingService implements MeetingService {
 
 		for (ParticipationInfoView p : list) {
 			// 취소 or 내보낸 당한 참여자는 스킵
-			if(p.getCanceledAt() != null || p.getBannedAt() !=null)
+			if(p.getCanceledAt() != null || p.getBannedAt() != null)
 				continue;
 
 			ParticipantResponse participant =
@@ -621,4 +622,5 @@ public class DefaultMeetingService implements MeetingService {
 	private void createNotification(int memberId, String url, int type) {
 		notificationDao.insertCommentNotification(memberId, url, type);
 	}
+	
 }

--- a/src/main/resources/static/js/comment/comment.js
+++ b/src/main/resources/static/js/comment/comment.js
@@ -123,7 +123,7 @@ export function getComment(meetingId, commentUl) {
 				if(c.countOfReply != 0)
 					countOfReply = "답글 " + c.countOfReply + "개";
 				let template = `
-					<li>
+					<li data-id="${c.id}">
 						<div class="profile">
 							<span class="profile__image"></span> 
 							<span class="profile__nickname">${c.nickname}</span> 
@@ -131,7 +131,6 @@ export function getComment(meetingId, commentUl) {
 							<button></button>
 						</div> <span class="comment__content">${c.content}</span>
 						<div class="comment__replies underline pointer">
-							<span class="hidden comment-id">${c.id}</span> 
 							<span class="pointer underline reply-cnt">${countOfReply}</span>
 							<span class="hidden pointer hidden reply-close">닫기</span>
 							<span class="pointer underline reply-write">답글 달기</span>

--- a/src/main/resources/static/js/comment/edit-reply.js
+++ b/src/main/resources/static/js/comment/edit-reply.js
@@ -41,8 +41,8 @@ function editReply(replyId, replyUl, profile){
                       class="reply__input"
                       name="reply-input"></textarea>
                   <div class="reply__btn-container">
-                      <span class="reply__btn btn btn-round cancel-btn">취소하기</span>
-                      <span class="reply__btn btn btn-round save-reply-edit"  >저장하기</span>
+                      <span class="reply__btn btn btn-round btn-cancel cancel-btn" id="edit-reply-cancel">취소하기</span>
+                      <span class="reply__btn btn btn-round btn-action save-reply-edit"  >저장하기</span>
                   </div>
               </div> 
                    `;
@@ -57,6 +57,12 @@ function editReply(replyId, replyUl, profile){
 		const editSaveBtn = document.querySelector(".save-reply-edit");
 		editSaveBtn.addEventListener("click",()=>{
 			saveEdit(replyId,replyUl,inputBox);
+		});
+		
+		document.querySelector("#edit-reply-cancel").addEventListener("click",()=>{
+			document.querySelector(".reply__input-container").remove();
+			linkContainer.classList.remove("hidden");
+			replyContainer.classList.remove("hidden");
 		});
 }
 

--- a/src/main/resources/static/js/comment/reply.js
+++ b/src/main/resources/static/js/comment/reply.js
@@ -70,7 +70,7 @@ export function writeReply(meetingId, groupId, parentId, replyUl, linkContainer)
                       name="reply-input"
                       placeholder="답글을 입력하세요."></textarea>
                   <div class="reply__btn-container">
-                      <span class="reply__btn btn btn-round btn-cancel cancel-btn">취소하기</span>
+                      <span class="reply__btn btn btn-round btn-cancel cancel-btn" id="reply-cancel">취소하기</span>
                       <span class="reply__btn btn btn-round btn-action register-btn">등록하기</span>
                   </div>
               </div> 
@@ -116,11 +116,10 @@ export function writeReply(meetingId, groupId, parentId, replyUl, linkContainer)
 					});
 		});//end of registerBtn event handler
 		//취소버튼에 이벤트핸들러 부착 
-		//document.querySelector(".reply__btn.cancel-btn").addEventListener("click",()=>{
-		//console.log(document.querySelector(".reply__btn.cancel-btn"))
-		//	document.querySelector(".reply__input-container").remove();
-		//	linkContainer.classList.remove("hidden");
-		//});
+		document.querySelector("#reply-cancel").addEventListener("click",()=>{
+			document.querySelector(".reply__input-container").remove();
+			linkContainer.classList.remove("hidden");
+		});
 }
 
 //답글 갯수 갱신

--- a/src/main/resources/static/js/comment/reply.js
+++ b/src/main/resources/static/js/comment/reply.js
@@ -79,7 +79,7 @@ export function writeReply(meetingId, groupId, parentId, replyUl, linkContainer)
 		linkContainer.insertAdjacentHTML("afterend", template);
 		const inputBox = document.querySelector("#reply-text");
 		inputBox.focus();
-		document.querySelector(".register-btn").addEventListener("click", () => {
+		document.querySelector(".reply__btn.register-btn").addEventListener("click", () => {
 			const replyText = document.querySelector("#reply-text").value;
 			
 			if(replyText==""){
@@ -116,10 +116,11 @@ export function writeReply(meetingId, groupId, parentId, replyUl, linkContainer)
 					});
 		});//end of registerBtn event handler
 		//취소버튼에 이벤트핸들러 부착 
-		document.querySelector(".cancel-btn").addEventListener("click",()=>{
-			document.querySelector(".reply__input-container").remove();
-			linkContainer.classList.remove("hidden");
-		});
+		//document.querySelector(".reply__btn.cancel-btn").addEventListener("click",()=>{
+		//console.log(document.querySelector(".reply__btn.cancel-btn"))
+		//	document.querySelector(".reply__input-container").remove();
+		//	linkContainer.classList.remove("hidden");
+		//});
 }
 
 //답글 갯수 갱신

--- a/src/main/resources/templates/meeting/detail.html
+++ b/src/main/resources/templates/meeting/detail.html
@@ -281,12 +281,12 @@
     <!--------------- 댓글 섹션 -------------------->
     <section class="comment">
 			<h2 class="comment__num" th:text="'댓글 ' + ${meeting.commentCount}+' 개'">N</h2>
-			<div class="comment__input-container">
+			<div class="comment__input-container ">
 				<textarea class="comment__input" name="comment-text"
 					id="comment-text" placeholder="댓글을 입력하세요."></textarea>
 				<div class="comment__btn-container">
 					<span class="reply__btn btn btn-round btn-cancel cancel-btn hidden">취소하기</span>
-					<span class="comment__btn btn btn-round btn-action modal__on-btn" id="register-btn" data-modal="">등록하기</span>
+					<span class="comment__btn btn btn-round btn-action modal__on-btn" data-modal="#dummy-modal" id="register-btn">등록하기</span>
 					<span class="hidden comment__btn btn btn-round btn-action" id="edit-save-btn">저장하기</span>
 				</div>
 			</div>
@@ -312,7 +312,7 @@
 							th:classappend="(${comment.countOfReply}==0)? 'hidden'"
 							th:text="'답글 ' + ${comment.countOfReply}+'개'"></span> 
 						<span class="hidden pointer reply-close">닫기</span> 
-						<span class="pointer underline reply-write modal__on-btn" data-modal="">답글 달기</span>
+						<span class="pointer underline reply-write modal__on-btn" data-modal="#dummy-modal">답글 달기</span>
 					</div>
 					<section class="reply hidden">
 						<ul class="reply__list">
@@ -321,6 +321,7 @@
 					</section>
 				</li>
 			</ul>
+			<div class="hidden" id="dummy-modal"></div>
 		</section>
     </main>
 </html>


### PR DESCRIPTION
## 🛠 작업사항
- defaultCommentService내에서 reply insert하는 메소드내에 미팅테이블의 comment 카운트를 증가시키는 명령줄이 있어서 제거함.
- defaultCommentService내에서 comment(reply공통) delete 하는 메소드내에서 comment deletion에 대해서만 카운트 감소시키도록 로직 변경
- comment & reply 관련 js 파일에서 e.target.closest() 급적용과정에서 생긴 오타&누락된 코드 수정.
- meetingController의 detailView에 연결된 defaultMeetingService의 getById함수내에 canceldAt != null 필터링 추가. line# 227~228