### PR TITLE
feat: 기본 모달 & 검색

### DIFF
--- a/src/main/vue/src/App.vue
+++ b/src/main/vue/src/App.vue
@@ -1,12 +1,5 @@
-<script setup>
-import { RouterLink, RouterView } from "vue-router";
-import Detail from "./views/meeting/Detail.vue";
-import Article from "./components/meeting/Article.vue";
-import Header from './components/header/header.vue'
-import Buttons from "./components/Buttons.vue";
-</script>
+<script setup></script>
 
 <template>
-  <Header/>
-  <router-view/>
+  <router-view />
 </template>

--- a/src/main/vue/src/assets/css/meeting/thumbnail-list.css
+++ b/src/main/vue/src/assets/css/meeting/thumbnail-list.css
@@ -1,0 +1,21 @@
+.meetings {
+  margin-top: 40px;
+}
+
+.meetings > ul {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 24px;
+}
+
+@media (min-width: 768px) {
+  .meetings > ul {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .meetings > ul {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/src/main/vue/src/components/header/header.vue
+++ b/src/main/vue/src/components/header/header.vue
@@ -90,7 +90,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 @import url(../../assets/css/component/header.css);
 @import url(../../assets/css/component/modal.css);
 </style>

--- a/src/main/vue/src/components/header/login-modal.vue
+++ b/src/main/vue/src/components/header/login-modal.vue
@@ -63,6 +63,7 @@ export default {
 </script>
 <style scoped>
 @import url(../../assets/css/component/login.css);
+@import url(../../assets/css/component/modal.css);
 
 .modal__body {
     display: flex;

--- a/src/main/vue/src/components/modal/Default.vue
+++ b/src/main/vue/src/components/modal/Default.vue
@@ -1,0 +1,72 @@
+<script setup>
+import { defineEmits } from "vue";
+
+const emit = defineEmits(["closeModal"]);
+
+function closeModal(e) {
+  // X버튼 클릭이라면 닫기
+  if (e.target.classList.contains("modal__close-btn")) {
+    emit("closeModal");
+    return;
+  }
+  // 모달 배경 클릭이 아니라면 return
+  if (!e.target.classList.contains("modal-default-wrap")) return;
+
+  emit("closeModal");
+}
+</script>
+
+<template>
+  <section class="modal-default-wrap" @click="closeModal($event)">
+    <div class="modal-default">
+      <div class="modal__header">
+        <span
+          class="icon icon-x pointer modal__close-btn"
+          @click="closeModal($event)"
+        ></span>
+      </div>
+      <div class="modal__body">
+        <slot name="modal-body"></slot>
+      </div>
+      <div class="modal__footer">
+        <slot name="modal-footer"></slot>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.modal-default-wrap {
+  background-color: rgba(0, 0, 0, 0.15);
+  position: fixed;
+  inset: 0; /*t, l, b, r 0*/
+}
+
+.modal-default {
+  position: relative;
+  top: 25%;
+  max-width: 360px;
+  height: fit-content;
+  background-color: white;
+  margin: 0 auto;
+  border: 1px solid #c4c4c4;
+  box-shadow: 0px 3px 8px rgba(0, 0, 0, 0.25);
+  border-radius: 10px;
+  font-size: 18px;
+  z-index: 999;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 16px;
+}
+
+.modal__body {
+  display: flex;
+  justify-content: center;
+  padding: 0 16px 24px 16px;
+  color: var(--dark-grey1);
+}
+</style>

--- a/src/main/vue/src/router/index.js
+++ b/src/main/vue/src/router/index.js
@@ -23,7 +23,8 @@ const router = createRouter({
             },
             {
               path: "search",
-              component: () => import("@/views/meeting/Detail.vue"),
+              component: () => import("@/views/meeting/Search.vue"),
+              alias: "/search",
             },
             {
               path: ":id(\\d+)", // matches only numbers

--- a/src/main/vue/src/views/Layout.vue
+++ b/src/main/vue/src/views/Layout.vue
@@ -1,14 +1,9 @@
-<script>
-// import Header from "./Hader.vue";
-// export default {
-//   components: {
-//     Header,
-//   },
-// };
+<script setup>
+import Header from "@/components/header/header.vue";
 </script>
 
 <template>
-  <!-- <Header /> -->
+  <Header />
   <main>
     <router-view></router-view>
   </main>

--- a/src/main/vue/src/views/meeting/List.vue
+++ b/src/main/vue/src/views/meeting/List.vue
@@ -6,7 +6,8 @@ import { useMeetingListStore } from "@/stores/meetingListStore";
 import Thumbnail from "@/components/meeting/Thumbnail.vue";
 import LoadingRoller from "@/components/LoadingRoller.vue";
 import OptionControll from "@/components/meeting/option-control/OptionControl.vue";
-import SearchBar from "../../components/meeting/option-control/SearchBar.vue";
+import SearchBar from "@/components/meeting/option-control/SearchBar.vue";
+import ModalDefault from "@/components/modal/Default.vue";
 
 // 검색을 위한 router
 const router = useRouter();
@@ -24,9 +25,7 @@ const state = reactive({
   }),
 });
 
-/**
- * meetingListStore의 상태가 변경될 때마다 모임 리스트를 새로 조회한다
- */
+// meetingListStore의 상태가 변경될 때마다 모임 리스트를 새로 조회한다 --------------
 watch(meetingListStore, async () => {
   state.lastId = null;
   const list = await requestList();
@@ -41,9 +40,7 @@ requestList().then((data) => {
   addMeetings(data);
 });
 
-/**
- * 무한 스크롤
- */
+// 무한 스크롤 -----------------------------------------------------------
 const scrollDirection = ref(0); // 스크롤 방향 정보 1: up -1 : down
 const scrollTrace = ref(0); // 이전 스크롤 방향을 추적
 
@@ -80,10 +77,7 @@ function onScrollDown(e) {
 
 document.addEventListener("scroll", onScrollDown);
 
-/**
- *  모임 리스트 요청 후 데이터 리턴
- *  @returns 모임[]
- */
+// 모임 리스트 요청 후 데이터 리턴 ----------------------------------------------
 async function requestList() {
   try {
     const res = await api.meeting.getThumbnailList(
@@ -124,17 +118,34 @@ function generateParamsWithStore(meetingListStore) {
   return params;
 }
 
+// 검색 -----------------------------------------------------------
+let isSearchKeywordNone = ref(false);
+
 /**
  * {@link SearchBar} 컴포넌트 searchFromSearchBar 에 의해 실행되는 검색 함수
  */
 function search(keyword) {
+  if (!keyword) {
+    isSearchKeywordNone.value = true;
+    return;
+  }
   router.push(`/search?q=${keyword}`);
+}
+
+function closeRequiredKeywordModal() {
+  isSearchKeywordNone.value = false;
 }
 </script>
 
 <template>
   <div class="content-wrap">
     <SearchBar @searchFromSearchBar="search" />
+    <ModalDefault
+      v-if="isSearchKeywordNone"
+      @closeModal="closeRequiredKeywordModal"
+    >
+      <template #modal-body>검색어를 입력해주세요.</template>
+    </ModalDefault>
     <OptionControll />
     <section class="meetings">
       <ul>

--- a/src/main/vue/src/views/meeting/List.vue
+++ b/src/main/vue/src/views/meeting/List.vue
@@ -165,30 +165,10 @@ function closeRequiredKeywordModal() {
 </template>
 
 <style scoped>
+@import url(@/assets/css/meeting/thumbnail-list.css);
+
 .content-wrap {
   max-width: 1200px;
-}
-
-.meetings {
-  margin-top: 40px;
-}
-
-.meetings > ul {
-  display: grid;
-  grid-template-columns: repeat(1, 1fr);
-  gap: 24px;
-}
-
-@media (min-width: 768px) {
-  .meetings > ul {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (min-width: 1200px) {
-  .meetings > ul {
-    grid-template-columns: repeat(3, 1fr);
-  }
 }
 
 .result-none {

--- a/src/main/vue/src/views/meeting/Search.vue
+++ b/src/main/vue/src/views/meeting/Search.vue
@@ -1,0 +1,186 @@
+<script setup>
+import { reactive, computed, watch, ref } from "vue";
+import { useRoute } from "vue-router";
+import api from "@/api/";
+import Thumbnail from "@/components/meeting/Thumbnail.vue";
+import LoadingRoller from "@/components/LoadingRoller.vue";
+
+const route = useRoute();
+
+const keyword = route.query.q; // 검색어
+
+const state = reactive({
+  meetings: [],
+  lastId: null,
+  throttling: null,
+  loadingOn: false,
+  isResultNone: computed(() => {
+    return state.meetings.length === 0;
+  }),
+  isToggleOn: true,
+});
+
+// isToggleOn의 상태가 변경될 때마다 모임 리스트를 새로 조회한다 --------------
+watch(state.isToggleOn, async () => {
+  state.lastId = null;
+  const list = await requestList();
+  resetMeetigns();
+  if (!list || list.length === 0) return;
+  addMeetings(list);
+});
+
+// 첫 meeting search page 조회시 호출
+requestList().then((data) => {
+  if (!data || data.length === 0) return;
+  addMeetings(data);
+});
+
+// 모임 리스트 요청 후 데이터 리턴 ----------------------------------------------
+async function requestList() {
+  try {
+    const res = await api.meeting.getThumbnailList(generateSearchParams(state));
+    return await res.json();
+  } catch (e) {
+    // TODO: 에러 모달
+    console.log(e);
+    alert("잠시후에 다시 시도해주세요");
+  }
+}
+
+function resetMeetigns() {
+  state.meetings = [];
+}
+
+function addMeetings(data) {
+  for (const m of data) {
+    state.meetings.push(m);
+  }
+}
+
+function generateSearchParams(state) {
+  const params = {};
+
+  // 토글 checked === true -> 모집 중인 모임만 보기
+  if (state.isToggleOn) params.isClosed = false;
+
+  // 스크롤 이벤트시 설정되는 리스트 중 마지막 요소 id
+  if (state.lastId) params.start = state.lastId;
+
+  params.keyword = keyword;
+
+  return params;
+}
+
+// 무한 스크롤 -----------------------------------------------------------
+const scrollDirection = ref(0); // 스크롤 방향 정보 1: up -1 : down
+const scrollTrace = ref(0); // 이전 스크롤 방향을 추적
+
+function onScrollDown(e) {
+  if (state.meetings === 0) return;
+  // 스크롤 방향 추적해서 방향 업데이트하기
+  const currentScrollY = window.scrollY;
+
+  if (currentScrollY > scrollTrace.value) scrollDirection.value = -1;
+  else if (currentScrollY < scrollTrace.value) scrollDirection.value = 1;
+  scrollTrace.value = currentScrollY;
+
+  const { scrollHeight, scrollTop, clientHeight } = document.documentElement;
+
+  // 쓰로틀링 통과, 스크롤이 화면의 아래 위치, 스크롤 방향이 아래일 때 다음 리스트 요청
+  if (
+    !state.throttling &&
+    scrollTop + clientHeight > scrollHeight - 5 &&
+    scrollDirection.value < 0
+  ) {
+    state.loadingOn = true;
+    state.throttling = setTimeout(async () => {
+      state.throttling = null;
+      state.loadingOn = false;
+      state.lastId = state.meetings[state.meetings.length - 1].id;
+
+      const list = await requestList();
+
+      if (!list || list.length === 0) return;
+      addMeetings(list);
+    }, 300);
+  }
+}
+
+document.addEventListener("scroll", onScrollDown);
+</script>
+
+<template>
+  <div class="content-wrap">
+    <div class="search-result">
+      <h2>
+        <strong>{{ keyword }}</strong> 검색결과
+      </h2>
+    </div>
+    <div>
+      <!-- TODO: 토글 -->
+    </div>
+    <section class="meetings">
+      <ul>
+        <li v-for="(meeting, idx) in state.meetings" :key="idx">
+          <Thumbnail :meeting="meeting" />
+        </li>
+      </ul>
+      <div v-if="state.isResultNone" class="result-none">
+        <p>
+          '<strong class="search-keyword">{{ keyword }}</strong
+          >'에 대한 검색 결과가 없어요 !
+        </p>
+        <p>검색할 단어를 변경하거나, 검색어를 확인해주세요.</p>
+      </div>
+    </section>
+
+    <div class="loading-wrap">
+      <LoadingRoller :isShow="state.loadingOn" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@import url(@/assets/css/meeting/thumbnail-list.css);
+
+.content-wrap {
+  max-width: 1200px;
+}
+
+.search-result {
+  width: 100%;
+  padding-top: 2rem;
+}
+
+.search-result > h2 {
+  font-size: 20px;
+}
+
+.search-result > h2 > strong {
+  font-weight: bold;
+}
+
+.result-none {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  color: var(--dark-grey2);
+  padding: 80px 0;
+}
+
+.result-none strong {
+  font-weight: bold;
+}
+
+@media (min-width: 768px) {
+  .result-none {
+    font-size: 20px;
+  }
+}
+
+.loading-wrap {
+  display: flex;
+  justify-content: center;
+  margin: 2rem auto;
+}
+</style>


### PR DESCRIPTION
## 🛠 작업사항
### 기본 모달 컴포넌트 구현
<img width="673" alt="스크린샷 2023-01-14 오후 6 28 48" src="https://user-images.githubusercontent.com/105474635/212465388-0ed2aede-70b1-4416-92b3-2528458bd160.png">

기본 모달을 구현했습니다
톡방에 설명 해놓았으니 참고해주세요
### [refactor: 계층형 라우터 구조를 반영한 views 컴포넌트 구조 반영](https://github.com/Z-P0P/ZPOP/commit/8f10f3cc771ccfde56d1e0499721c4bad3927ace)
추후 관리자 vue router까지 고려해서 수업 때 배운걸 반영했습니다
### 헤더, 로그인 모달 컴포넌트 style에 scoped 적용
다른 컴포넌트(새로 만든 모달 컴포넌트)까지 CSS 영향받아서 적용했습니다.

### 검색 구현
<img width="922" alt="스크린샷 2023-01-14 오후 6 29 48" src="https://user-images.githubusercontent.com/105474635/212465417-034a1dec-bcb7-4751-b71b-4130244cdeab.png">

모임 검색 구현했읍니다.
검색 결과가 없으면`(검색어) 검색결과` 가 중앙으로 줄어드는 CSS 이슈가 있읍니다
<img width="922" alt="스크린샷 2023-01-14 오후 6 30 10" src="https://user-images.githubusercontent.com/105474635/212465427-db537e05-5851-410b-b58a-bbd6f860208b.png">

