### PR TITLE
fix: 기존 탭에서 로그인한 상태에서 새 탭으로 접속 시 로그인 정보가 유지되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/zpop/web/controller/LoginController.java
+++ b/src/main/java/com/zpop/web/controller/LoginController.java
@@ -128,51 +128,25 @@ public class LoginController {
 		result.put("profileImagePath", member.getProfileImagePath());
 		return ResponseEntity.ok(result);
 	}
-/*
- * naverLogin과 관련된 별도의 컨트롤러
-	@GetMapping("oauth/naver")
-	public String naverLogin(@RequestParam @Nullable String code
-			, @RequestParam @Nullable String state
-			, HttpSession session) throws IOException, InterruptedException {
 
-		LoginService loginService = loginServiceMap.get("naverLoginService");
 
-		
-		if (session.getAttribute("memberId") != null) {
-			System.out.println("이미 로그인한 사용자임");
-			return "redirect:/login";
+	@GetMapping("me")
+	@ResponseBody
+	public ResponseEntity<?> getLoginInfo(@AuthenticationPrincipal ZpopUserDetails userDetails){
+		Map<String, Object> result = new HashMap<>();
+
+		if(userDetails == null){
+			result.put("code", "NOT_AUTHENTICATED");
+			return ResponseEntity.ok(result);
 		}
 
-		if (code == null) {
-			System.out.println("로그인에 실패하였음");
-			return "redirect:/login";
-		}
+		result.put("code", "AUTHENTICATED");
+		result.put("nickname", userDetails.getUsername());
+		result.put("profileImagePath", userDetails.getProfileImagePath());
 
-		System.out.println("code: " + code);
-		System.out.println("state: " + state);
-		String accessToken = "";
-
-		accessToken = (loginService.getAccessToken(code, state));
-		System.out.println(accessToken);
-		String socialId = loginService.getSocialId(accessToken);
-		int socialIdType = 2;
-		Member member = memberDao.getBySocialId(socialId);
-		if (member == null) {
-			session.setAttribute("socialId", socialId);
-			session.setAttribute("socialIdType", socialIdType);
-			return "redirect:/register";
-		}
-		
-		session.setAttribute("memberId", member.getId());
-		session.setAttribute("socialId", member.getSocialId());
-		session.setAttribute("nickname", member.getNickname());
-		session.setAttribute("profileImg", 
-				(member.getProfileImagePath()== null ? "user-profile.svg" : member.getProfileImagePath()));
-		
-		return "redirect:/login";
+		return ResponseEntity.ok(result);
 
 	}
-*/
 	
 	private void createNotification(int memberId, String url, int type) {
 		notificationDao.insertCommentNotification(memberId,url,type);

--- a/src/main/vue/src/stores/memberStore.js
+++ b/src/main/vue/src/stores/memberStore.js
@@ -1,22 +1,38 @@
+import { reactive } from 'vue';
 import { defineStore } from 'pinia';
 
 export const useMemberStore = defineStore('member', {
     state: () => {
+        let info = reactive({
+            nickname : null,
+            profileImagePath : null,
+        })
+        const storedMemberInfo = JSON.parse(window.sessionStorage.getItem('ZPOP_MEMBER_INFO'));
+
+        if (storedMemberInfo != null){
+            info = storedMemberInfo;
+        }
+        else{
+            fetch('/api/login/me')
+                .then(res=>res.json())
+                .then(data=>{
+                    if (data.code === "AUTHENTICATED"){
+                        info.nickname = data.nickname;
+                        info.profileImagePath = data.profileImagePath;
+                    }
+                    window.sessionStorage.setItem('ZPOP_MEMBER_INFO', 
+                    JSON.stringify(info));
+                })
+        }
+
         return{
-            memberInfo : {}
+            memberInfo : info,
         }
     },
 
     actions: {
         setInfo(memberInfo){
             this.memberInfo = memberInfo;
-        }
+        },
     },
-
-    // 새로고침해도 로그인 정보가 남아있을 수 있도록 sessionStorage에 저장
-    // 기본 js function 말고, pinia-plugin-persist 라이브러리 사용
-    // 사용하기 위해서는 App.vue에서 import 및 pinia에 설정해주어야 함
-    persist:{
-        enabled: true,
-    }
 })


### PR DESCRIPTION
## 🛠 작업사항
- 로그인 이후 새 탭에서 다시 접속했을 때 로그인 상태가 유지되지 않는 문제 해결
### 수정 전
- pinia-plugin-persist 을 사용해서 새로고침 시 로그인상태가 유지되는 것은 확인을 했음
- 그러나, 새 탭에서 주소 입력하여 들어갔을 때 로그인상태가 유지되지 않은 현상이 있었음
- pinia-plugin은 기본적으로 sessionStorage를 사용하는 것이기 때문에, 새 탭에서는 로그인이 유지되지 않는 것이 정상임

### 수정 후
- pinia-plugin-persist를 사용하는 것이 크게 의미가 없는 것 같아서 사용하지 않는 것으로 변경
- 최초 로그인 시 sessionStorage에 직접 로그인 정보 저장 (닉네임, 프로필정보) -> 저장되는 이름은 ('ZPOP_MEMBER_INFO')
- 처음 사이트에 접속했을 때 sessionStorage 정보를 확인하고, null이면 서버에 userDetail 정보를 요청
- userDetail에 정보가 있으면 이를 sessionStorage에 저장하고, 헤더 정보를 갱신함

## 💡 기타
- N/A
