### PR TITLE
[FEAT] 메인의 모임글 조회 화면에서 지역 옵션을 선택하는 기능 추가

### DIFF
--- a/src/main/vue/src/components/meeting/SelectBox.vue
+++ b/src/main/vue/src/components/meeting/SelectBox.vue
@@ -2,9 +2,7 @@
     <div class="select-box select-box--input" :class="{'select-box--error':option.hasError}" @click="onSelectBoxClick">
         <span>{{ option.placeholder }}</span>
         <ul v-show="option.isOpened" class="select-box__options" id="select-box">
-            <li @click.stop="onOptionClick" v-for="(item, index) in option.items" :key="index" :data-id="item.id">
-                {{ item.name || item.type }}
-            </li>
+            <li @click.stop="onOptionClick" v-for="(item, index) in option.items" :key="index" :data-id="item.id">{{ item.name || item.type }}</li>
         </ul>
     </div>
 </template>

--- a/src/main/vue/src/components/meeting/option-control/OptionControl.vue
+++ b/src/main/vue/src/components/meeting/option-control/OptionControl.vue
@@ -2,6 +2,8 @@
 import { useMeetingListStore } from "@/stores/meetingListStore";
 import Category from "./Category.vue";
 import SoftToggle from "@/components/button/SoftToggle.vue";
+import Region from "@/components/meeting/option-control/Region.vue";
+
 
 const meetingListStore = useMeetingListStore();
 
@@ -19,7 +21,7 @@ function handleToggle(e) {
     <section class="option-control">
       <Category @selectCategory="categoryId" />
       <div class="options-detail">
-        <!-- <Region/> -->
+        <Region/>
         <div class="option-control__activate">
           <span>모집 중만 보기</span>
           <SoftToggle
@@ -80,6 +82,21 @@ function handleToggle(e) {
   .option-control__activate > span {
     font-size: 18px;
     color: var(--dark-grey2);
+  }
+}
+
+.options-detail {
+  width: 100%;
+  display: flex;
+  justify-content: end;
+  align-items: center;
+  margin: 1rem auto;
+  column-gap: 10px;
+}
+
+@media (min-width: 1200px) {
+  .options-detail {
+    justify-content: flex-start;
   }
 }
 </style>

--- a/src/main/vue/src/components/meeting/option-control/Region.vue
+++ b/src/main/vue/src/components/meeting/option-control/Region.vue
@@ -1,0 +1,129 @@
+<template>
+    <select-box class="select-box--round region-category"
+    @selectBoxClick="selectBoxClickedHandler"
+    @optionClick="optionClickedHandler"            
+    :option="option"></select-box>
+    <div class="meeting-region" 
+    v-for="(item,index) in selectedRegions" :key="index"
+    :data-region-id="item.id">
+        <span>{{item.name}}</span>
+        <img @click.stop="cancelRegionHandler($event,index)" class="meeting-active-option" src="/images/icon/x-white.svg" alt="delete-region">
+    </div>
+</template>
+
+<script setup>
+import SelectBox from '../SelectBox.vue';
+import { reactive } from 'vue';
+import { useMeetingListStore} from '@/stores/meetingListStore'
+
+const store = useMeetingListStore();
+const option = reactive({
+    id: 'region',
+    isOpened : false, 
+    placeholder: '지역',
+    items: [
+            {id:1,name:'서울'},
+            {id:2,name:'인천/경기'},
+            {id:3,name:'경남/부산/울산'},
+            {id:4,name:'충청/대전/세종'},
+            {id:5,name:'전라/광주'},
+            {id:6,name:'강원'},
+            {id:7,name:'경북/대구'},
+            {id:8,name:'제주'},
+            {id:9,name:'온라인'}
+        ]
+});
+
+const selectedRegions = reactive([]);
+
+const selectBoxClickedHandler = () => {
+    option.isOpened = !option.isOpened;
+}
+
+const optionClickedHandler = (optionId, name, dataId) => {
+    option.isOpened = !option.isOpened;
+    console.log('옵션클릭')
+    const index = getIndexOfSelectedRegion(dataId);
+    
+    if (index != -1){
+        selectedRegions.splice(index,1);
+    }
+    
+    else if (selectedRegions.length >= 3){
+        selectedRegions.pop();
+    }
+    else{
+        selectedRegions.push(
+            {
+                id : dataId,
+                name: name,
+            }
+        )
+    }
+    updateRegions();
+    return;
+}
+
+const getIndexOfSelectedRegion = (dataId) => {
+    console.log(selectedRegions);
+    for (let i = 0; i < selectedRegions.length; i++){
+        console.log(selectedRegions[i].id, dataId);
+        if (selectedRegions[i].id === dataId){
+            return i;
+        }
+    }
+    return -1;
+}
+
+const cancelRegionHandler = (event, index) => {
+    selectedRegions.splice(index,1);
+    updateRegions();
+}
+
+const updateRegions= () => {
+    const params = [];
+    selectedRegions.forEach(region=>params.push(region.id));  
+    store.setRegions(params);
+}
+
+
+</script>
+
+<style>
+@import url('../../../assets/css/component/select.css');
+.region-category {
+  width: 220px;
+  display: none;
+}
+
+@media (min-width: 1200px) {
+  .region-category {
+    display: flex;
+  }
+}
+
+.region-category{
+	margin-top:0;
+}
+
+.meeting-region{
+    min-width: 128px;
+    height:52px;
+    background-color: #177DD7; /* true blue*/
+    border-radius: 50px;
+    color: white;
+    font-weight: bold;
+    font-size: 18px;
+    display: inline-flex;
+    padding:0 24px;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.meeting-region > img{
+    width: 24px;
+    height: 24px;
+    margin-left: 16px;
+    cursor: pointer;
+}
+</style>

--- a/src/main/vue/src/stores/meetingListStore.js
+++ b/src/main/vue/src/stores/meetingListStore.js
@@ -14,8 +14,9 @@ export const useMeetingListStore = defineStore("meetingList", {
     selectCategory(categoryId) {
       this.category = categoryId;
     },
-    selectRegion(regioinId) {},
-    revmoeRegion(regioinId) {},
+    setRegions(selectedRegions){
+      this.regions = selectedRegions;
+    },
     changeToggle() {
       this.isToggleOn = !this.isToggleOn;
     },

--- a/src/main/vue/src/views/meeting/List.vue
+++ b/src/main/vue/src/views/meeting/List.vue
@@ -114,7 +114,7 @@ function generateParamsWithStore(meetingListStore) {
     params.category = meetingListStore.category;
   // 지역 옵션
   if (meetingListStore.regions && meetingListStore.regions.length !== 0)
-    params.regions = regions;
+    params.regions = meetingListStore.regions;
   // 스크롤 이벤트시 설정되는 리스트 중 마지막 요소 id
   if (state.lastId) params.start = state.lastId;
 


### PR DESCRIPTION
## 🛠 작업사항
- 1차 프로젝트에서  찬우님이 구현하였던 지역옵션 선택을 통한 모임글 조회 기능을 추가하였습니다.
### 수정 전
- 모임글 조회 시 지역옵션을 선택하여 추가하는 기능이 vue로 구현되어있지 않았음

### 수정 후
- 지역옵션을 선택하여 선별적으로 조회하는 기능을 추가하였음
- 지역옵션 선택에 대한 로직은 다음과 같습니다.

1. 지역 옵션을 선택하면 오른쪽에 파란색 아이콘으로 누적해서 옵션이 선택됨
2. 누적은 3개까지 가능하고, 3개인 상태에서 지역옵션을 새로 선택하는 경우 가장 마지막에 있는 지역옵션을 제거하고 추가함
3. 이미 존재하는 지역명을 다시 클릭하는 경우 해당 선택된 내역이 삭제됨

## 💡 기타
- X아이콘 image 요청이 매번 발생하고, 이로 인해서 이미지 로딩시간이 있는데, 기존에 다운받은 이미지를 왜 재요청하는지 모르겠습니다.
