### PR TITLE
feat: detail article btn

### DIFF
--- a/src/main/java/com/zpop/web/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/zpop/web/dto/MeetingDetailResponse.java
@@ -1,8 +1,11 @@
 package com.zpop.web.dto;
 
+import lombok.Getter;
+
 import java.util.Date;
 import java.util.List;
 
+@Getter
 public class MeetingDetailResponse {
     private int id;
     private String title;
@@ -47,159 +50,6 @@ public class MeetingDetailResponse {
         this.hasParticipated = hasParticipated;
         this.isClosed = isClosed;
         this.participants = participants;
-        this.comments = comments;
-    }
-
-    public int getId() {
-        return this.id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public String getTitle() {
-        return this.title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public Date getStartedAt() {
-        return this.startedAt;
-    }
-
-    public void setStartedAt(Date startedAt) {
-        this.startedAt = startedAt;
-    }
-
-    public String getTextStartedAt() {
-        return this.textStartedAt;
-    }
-
-    public void setTextStartedAt(String textStartedAt) {
-        this.textStartedAt = textStartedAt;
-    }
-
-    public String getDetailRegion() {
-        return this.detailRegion;
-    }
-
-    public void setDetailRegion(String detailRegion) {
-        this.detailRegion = detailRegion;
-    }
-
-    public String getContent() {
-        return this.content;
-    }
-
-    public void setContent(String content) {
-        this.content = content;
-    }
-
-    public String getCategoryName() {
-        return this.categoryName;
-    }
-
-    public void setCategoryName(String categoryName) {
-        this.categoryName = categoryName;
-    }
-
-    public String getRegionName() {
-        return this.regionName;
-    }
-
-    public void setRegionName(String regionName) {
-        this.regionName = regionName;
-    }
-
-    public int getMaxMember() {
-        return this.maxMember;
-    }
-
-    public void setMaxMember(int maxMember) {
-        this.maxMember = maxMember;
-    }
-
-    public String getGenderCategory() {
-        return this.genderCategory;
-    }
-
-    public void setGenderCategory(String genderCategory) {
-        this.genderCategory = genderCategory;
-    }
-
-    public String getAgeRange() {
-        return this.ageRange;
-    }
-
-    public void setAgeRange(String ageRange) {
-        this.ageRange = ageRange;
-    }
-
-    public int getRegMemberId() {
-        return this.regMemberId;
-    }
-
-    public void setRegMemberId(int regMemberId) {
-        this.regMemberId = regMemberId;
-    }
-
-    public int getViewCount() {
-        return this.viewCount;
-    }
-
-    public void setViewCount(int viewCount) {
-        this.viewCount = viewCount;
-    }
-
-    public int getCommentCount() {
-        return this.commentCount;
-    }
-
-    public void setCommentCount(int commentCount) {
-        this.commentCount = commentCount;
-    }
-
-    public boolean isMyMeeting() {
-        return this.isMyMeeting;
-    }
-
-   
-    public void setMyMeeting(boolean isMyMeeting) {
-        this.isMyMeeting = isMyMeeting;
-    }
-
-    public boolean hasParticipated() {
-        return this.hasParticipated;
-    }
-
-    public void setParticipated(boolean hasParticipated) {
-        this.hasParticipated = hasParticipated;
-    }
-
-    public boolean isClosed() {
-        return this.isClosed;
-    }
-
-    public void setClosed(boolean isClosed) {
-        this.isClosed = isClosed;
-    }
-
-    public List<ParticipantResponse> getParticipants() {
-        return this.participants;
-    }
-
-    public void setParticipants(List<ParticipantResponse> participants) {
-        this.participants = participants;
-    }
-
-    public List<CommentResponse> getComments() {
-        return this.comments;
-    }
-
-    public void setComments(List<CommentResponse> comments) {
         this.comments = comments;
     }
 

--- a/src/main/vue/src/assets/css/meeting/article.css
+++ b/src/main/vue/src/assets/css/meeting/article.css
@@ -101,7 +101,6 @@ article{
   } 
    
   span.btn.btn-round{
-    background-color: var(--main-color);
     position: relative;
     left: 0;
     bottom: 0;
@@ -155,7 +154,6 @@ article{
     }
       
       span.btn.btn-round{
-        background-color: var(--main-color);
         width: 100%;
         text-align: center;
        

--- a/src/main/vue/src/components/button/Round.vue
+++ b/src/main/vue/src/components/button/Round.vue
@@ -1,0 +1,11 @@
+<script setup></script>
+
+<template>
+
+  <span class="btn btn-round btn-action">
+    <slot name="content"> default </slot>
+  </span>
+
+</template>
+
+<style></style>

--- a/src/main/vue/src/components/button/RoundDisabled.vue
+++ b/src/main/vue/src/components/button/RoundDisabled.vue
@@ -1,0 +1,11 @@
+<script setup></script>
+
+<template>
+
+  <span class="btn btn-round btn-dead">
+    <slot name="content"> default </slot>
+  </span>
+
+</template>
+
+<style></style>

--- a/src/main/vue/src/components/meeting/Article.vue
+++ b/src/main/vue/src/components/meeting/Article.vue
@@ -1,10 +1,8 @@
-
 <template>
-
   <article>
     <header>
       <div class="category-wrap">
-        <span class="category">{{ article.categoryName}}</span>
+        <span class="category">{{ article.categoryName }}</span>
       </div>
       <div class="title-container">
         <h2 class="title">{{ article.title }}</h2>
@@ -18,7 +16,7 @@
       </div>
       <div class="region-container">
         <span class="icon-location16"></span>
-       
+
         <span>{{ article.region }}</span>
         <span>{{ article.regionName }}</span>
       </div>
@@ -35,26 +33,34 @@
         <li>#{{ article.genderCategory }}</li>
       </ul>
       <div class="views">조회수 {{ article.viewCount }}회</div>
-      <!-- TODO: 버튼 컴포넌트화 -->
       <div class="control-btn-wrap">
-    <span class="btn btn-round">참여하기</span>
-  </div>
+        <RoundDisabled v-if="article.closed">
+          <template #content> 모집완료 </template>
+        </RoundDisabled>
+        <Round v-else-if="article.myMeeting">
+          <template #content> 마감하기 </template>
+        </Round>
+        <Round v-else-if="article.hasParticipated">
+          <template #content> 참여취소 </template>
+        </Round>
+        <Round v-else>
+          <template #content> 참여하기 </template>
+        </Round>
+      </div>
     </div>
   </article>
-
 </template>
 
-<script>
-export default {
-  name: "MeetingArticle",
-  //props 받는다.. 
-  props: {
-    article: Object,
-  },
-};
+<script setup>
+import { defineProps } from "vue";
+import Round from "../button/Round.vue";
+import RoundDisabled from "../button/RoundDisabled.vue";
+
+const props = defineProps({
+  article: Object,
+});
 </script>
 
-<style >
-  @import url(../../assets/css/meeting/article.css);
- 
+<style>
+@import url(../../assets/css/meeting/article.css);
 </style>

--- a/src/main/vue/src/views/meeting/Detail.vue
+++ b/src/main/vue/src/views/meeting/Detail.vue
@@ -1,19 +1,19 @@
-
 <!-- detail vue = 화면 / article 화면의 구성 요소중 한 부분-->
 <script>
-import { reactive,ref } from "vue";
+import { reactive, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import api from "@/api"; //index.js
 import Article from "@/components/meeting/Article.vue";
 import Participants from "@/components/meeting/Participants.vue";
 import CommentList from "@/components/comment/CommentList.vue";
+import { ServerException } from "@/utils/ServerException";
 
 export default {
   name: "MeetingDetail",
   components: {
-    'Article':Article,
-    'Participants':Participants,
-    'CommentList':CommentList,
+    Article: Article,
+    Participants: Participants,
+    CommentList: CommentList,
   },
   setup() {
     const state = reactive({
@@ -21,51 +21,53 @@ export default {
     });
     // 모임 정보 조회 reactive는 view단과 model단 일치
     const route = useRoute();
-    const getDetail = () => {
+    const router = useRouter();
+
+    const getDetail = async () => {
       try {
-        api.meeting
-            .getDetail(route.params.id)
-            .then(res => res.json())
-            .then(data => {state.detail = data});
+        const res = await api.meeting.getDetail(route.params.id);
+        if (!res.ok) throw new ServerException(res);
+        const data = await res.json();
+        state.detail = data;
       } catch (e) {
-        console.log(e);
-        alert("잠시 후에 다시 시도해주세요");
+        // 존재하지 않는 meeting id
+        if (e.res.status === 404) router.push("/404");
       }
     };
+
     getDetail();
 
-    const newComment = () =>{
-      getDetail(route.params.id);
-    }
-    function increaseCounter(){
+    const newComment = async () => {
+      await getDetail(route.params.id);
+    };
+    function increaseCounter() {
       state.detail.commentCount++;
     }
-    
-    return { state,newComment,getDetail, increaseCounter}; //script에서 return된 값이 model
-  }
 
-}
+    return { state, newComment, getDetail, increaseCounter }; //script에서 return된 값이 model
+  },
+};
 </script>
 <template>
   <div class="content-wrap">
-  <Article :article="state.detail"/>
-  <Participants :detail="state.detail"/> 
-  <CommentList :detail="state.detail" @newComment="newComment" @counterIncreased="increaseCounter"/> 
-  
-
+    <Article :article="state.detail" />
+    <Participants :detail="state.detail" />
+    <CommentList
+      :detail="state.detail"
+      @newComment="newComment"
+      @counterIncreased="increaseCounter"
+    />
   </div>
 </template>
 <style scoped>
-       
-.content-wrap{
-  
+.content-wrap {
   max-width: 783px;
   width: 100%;
   padding: 1.2rem;
- }
-  @media (min-width: 576px) {
-.content-wrap{
-     padding: 4rem;
+}
+@media (min-width: 576px) {
+  .content-wrap {
+    padding: 4rem;
   }
 }
 </style>


### PR DESCRIPTION
## 🛠 작업사항
- article.css 버튼에 먹혀있던 main-color, grey 색을 뺐습니다. 대신 btn-dead, btn-action 클래스를 추가하여 색을 적용 했습니다.
- 동글동글 라운드 버튼 메인컬러, 회색 버전 컴포넌트화 했습니다 
[feat: Round, RoundDisabled button components](https://github.com/Z-P0P/ZPOP/commit/e6de41f31decdf5fc9fc9fa2af8c5b41054e9499)
- MeetingDetailResponse에 Getter 롬복 추가했습니다. hasParticipated 값도 잘 넘어오네요
[MeetingDetailResponse.java](https://github.com/Z-P0P/ZPOP/commit/85c048da41ddca1d81d420ccba7e97e8331c7a78)
- 상황에 맞는 모임 참여하기, 모집완료, 마감하기, 참여취소 버튼 렌더링을 구현했습니다
[feat: implement of meeting control-btn that changes for each situation](https://github.com/Z-P0P/ZPOP/commit/b7bd1156a3ab7a94fdfd19b6f163c92914a7f733)
- 모임 Detail.vue에 유효하지 않는 Id로 요청시 404 vue로 이동하게 구현했습니다
[feat: add 404 handle Detail.vue](https://github.com/Z-P0P/ZPOP/commit/dfec582309236bb3810e609a184475ac5cc9cfc1)

