### PR TITLE
feat: 모임 마감하기 + 모임 상세 store

### DIFF
--- a/src/main/java/com/zpop/web/controller/MeetingController.java
+++ b/src/main/java/com/zpop/web/controller/MeetingController.java
@@ -182,7 +182,6 @@ public class MeetingController {
 	}
 	
 	@PatchMapping("/{id}/close")
-	@ResponseBody
 	public boolean closeMeeting(@PathVariable int id,
 			@AuthenticationPrincipal ZpopUserDetails userDetails) {
 		Member member = new Member();

--- a/src/main/vue/src/api/meeting.js
+++ b/src/main/vue/src/api/meeting.js
@@ -68,6 +68,15 @@ function leave(id) {
   });
 }
 
+/**
+ * 모임 마감하기
+ */
+function close(id) {
+  return fetch(`/api/meeting/${id}/close`, {
+    method: "PATCH"
+  }) ;
+}
+
 export default {
   getThumbnailList,
   getDetail,
@@ -78,4 +87,5 @@ export default {
   participate,
   getParticipant,
   leave,
+  close
 };

--- a/src/main/vue/src/components/comment/CommentList.vue
+++ b/src/main/vue/src/components/comment/CommentList.vue
@@ -1,69 +1,76 @@
 <script setup>
-  import { setMapStoreSuffix } from 'pinia';
-  import { defineProps, defineEmits, reactive, ref, onMounted } from 'vue';
-  import api from "@/api";
-  import Comment from './Comment.vue';
+import { defineProps, defineEmits, reactive, ref, onMounted } from "vue";
+import api from "@/api";
+import { useMeetingDetailStore } from "@/stores/meetingDetailStore";
+import Comment from "./Comment.vue";
 
-  const props = defineProps({
-    detail:Object
+const meetingDetalStore = useMeetingDetailStore();
+
+const emit = defineEmits(["newComment"]);
+const inputs = { f1: ref() };
+onMounted(() => {
+  const input = inputs["f1"].value;
+  input.focus();
+});
+
+function registerComment(refId) {
+  const data = {};
+  data.meetingId = meetingDetalStore.id; //미팅 id
+  data.content = document.querySelector("#comment-text").value;
+  const dataJSONStr = JSON.stringify(data);
+  api.comment.registerComment(dataJSONStr).then((res) => {
+    if (res.ok) {
+      console.log("댓글 등록됨");
+      emit("newComment");
+      const input = inputs[refId].value;
+      input.value = "";
+    } else alert("시스템 장애로 등록이 안되고 있습니다");
   });
-  const emit = defineEmits([
-    'newComment',
-    'counterIncreased'
-  ]);
-  const inputs = {f1:ref()}
-  onMounted(() => {
-    const input = inputs['f1'].value;
-    input.focus();
-  })
-  
-  function registerComment(refId){
-    const data = {};
-    data.meetingId = props.detail.id; //미팅 id
-    data.content = document.querySelector("#comment-text").value;
-    const dataJSONStr = JSON.stringify(data);
-    api.comment.registerComment(dataJSONStr)
-      .then(res=>{
-        if(res.ok){
-          console.log("댓글 등록됨");
-          emit('newComment');
-          const input = inputs[refId].value;
-          input.value="";
-        }
-        else 
-          alert("시스템 장애로 등록이 안되고 있습니다")
-      })
-  }
-  function increaseCounter(){
-    emit('counterIncreased');
-    //countOfComment.value++;
-  }
+}
 </script>
 
 <template>
   <section class="comment">
-    <h2 class="comment__num">댓글 {{ detail.commentCount }} 개</h2>
+    <h2 class="comment__num">댓글 {{ meetingDetalStore.commentCount }} 개</h2>
     <div class="comment__input-container">
-    <textarea class="comment__input" name="comment-text"
-                      id="comment-text" placeholder="댓글을 입력하세요." :ref="inputs.f1"></textarea>
+      <textarea
+        class="comment__input"
+        name="comment-text"
+        id="comment-text"
+        placeholder="댓글을 입력하세요."
+        :ref="inputs.f1"
+      ></textarea>
       <div class="comment__btn-container">
-        <span class="reply__btn btn btn-round btn-cancel cancel-btn hidden">취소하기</span>
-        <span class="comment__btn btn btn-round btn-action modal__on-btn" id="register-btn" data-modal="#dummy-modal" @click="registerComment('f1')">등록하기</span>
-        <span class="hidden comment__btn btn btn-round btn-action" id="edit-save-btn">저장하기</span>
+        <span class="reply__btn btn btn-round btn-cancel cancel-btn hidden"
+          >취소하기</span
+        >
+        <span
+          class="comment__btn btn btn-round btn-action modal__on-btn"
+          id="register-btn"
+          data-modal="#dummy-modal"
+          @click="registerComment('f1')"
+          >등록하기</span
+        >
+        <span
+          class="hidden comment__btn btn btn-round btn-action"
+          id="edit-save-btn"
+          >저장하기</span
+        >
       </div>
     </div>
     <ul class="comment__list">
-      <li v-for="(comment, index) in detail.comments" :key="index"> 
-        <Comment :comment="comment" @counterIncreased="increaseCounter"/>
+      <li v-for="(comment, index) in meetingDetalStore.comments" :key="index">
+        <Comment
+          :comment="comment"
+          @counterIncreased="meetingDetalStore.increaseCommentCount"
+        />
       </li>
     </ul>
   </section>
 </template>
 
 <style scoped>
-
- @import url(@/assets/css/meeting/component/select.css);
- @import url(@/assets/css/meeting/component/profile-box.css);
- @import url(@/assets/css/meeting/component/comment.css);
-
+@import url(@/assets/css/meeting/component/select.css);
+@import url(@/assets/css/meeting/component/profile-box.css);
+@import url(@/assets/css/meeting/component/comment.css);
 </style>

--- a/src/main/vue/src/components/meeting/Participants.vue
+++ b/src/main/vue/src/components/meeting/Participants.vue
@@ -1,63 +1,74 @@
 <script setup>
-import { setMapStoreSuffix } from 'pinia';
-import { computed,defineProps,ref } from 'vue';
+import { computed, defineProps, ref } from "vue";
+import { useMeetingDetailStore } from "@/stores/meetingDetailStore";
 import UserProfile from "@/components/meeting/UserProfile.vue";
 
-const props = defineProps({
-  detail: Object
-})
+const meetingDetailStore = useMeetingDetailStore();
 
 let isOpen = ref(false);
 
 let clickedParticipantId = ref(null);
 
 // 참여자를 클릭하였을때 참여자 정보 모달을 뒤워주는 함수
-function handleModal(event){
-      isOpen.value = true;
-      clickedParticipantId.value = event.target.getAttribute('data-id');
+function handleModal(event) {
+  isOpen.value = true;
+  clickedParticipantId.value = event.target.getAttribute("data-id");
 }
 
 const participantNum = computed(() => {
   // 데이터에서 불러온 참여자가 없을 시 0을 리턴
-  if (props.detail.participants === undefined) return 0;
-  const length = props.detail.participants.length;
+  if (meetingDetailStore.participants === undefined) return 0;
+  const length = meetingDetailStore.participants.length;
   return length;
-})
-
+});
 </script>
 
 <template>
-    <section class="participant">
-        <div class="participant__num">
-            <span>참가자</span>
-            <span id="participant-count">{{ participantNum }}</span>
-            <span>/</span>
-            <span>{{ props.detail.maxMember }}</span>
-            <span class="icon pointer icon-arrow-up"></span>
-            <span class="icon pointer hidden icon-arrow-down"></span>
+  <section class="participant">
+    <div class="participant__num">
+      <span>참가자</span>
+      <span id="participant-count">{{ participantNum }}</span>
+      <span>/</span>
+      <span>{{ meetingDetailStore.maxMember }}</span>
+      <span class="icon pointer icon-arrow-up"></span>
+      <span class="icon pointer hidden icon-arrow-down"></span>
+    </div>
+    <ul class="participant__list">
+      <li
+        v-for="(participant, idx) in meetingDetailStore.participants"
+        :key="participant.participantId"
+      >
+        <div class="participant__info">
+          <img
+            src="/images/icon/user-profile-grey.svg"
+            v-bind:data-id="participant.participantId"
+            @click.prevent="handleModal"
+          />
+          <span
+            v-bind:data-id="participant.participantId"
+            @click.prevent="handleModal"
+            >{{ participant.nickname }}</span
+          >
         </div>
-        <ul class="participant__list">
-            <li v-for="(participant, idx) in detail.participants" :key = "participant.participantId">
-              <div class="participant__info">
-                <img src="/images/icon/user-profile-grey.svg" v-bind:data-id="participant.participantId" @click.prevent="handleModal">
-                <span v-bind:data-id="participant.participantId" @click.prevent="handleModal">{{ participant.nickname }}</span>
-              </div>
-            </li>
-        </ul>
-        <UserProfile v-if="isOpen" :userDetail="detail" :participantId="clickedParticipantId"/>
-    </section>
+      </li>
+    </ul>
+    <UserProfile
+      v-if="isOpen"
+      :userDetail="detail"
+      :participantId="clickedParticipantId"
+    />
+  </section>
 </template>
 
 <style>
-
 .main {
-    margin: 2rem auto 4rem auto;
-    
-    max-width: 792px;
+  margin: 2rem auto 4rem auto;
+
+  max-width: 792px;
 }
 
 .main > section {
-    margin: 1rem 20px;
+  margin: 1rem 20px;
 }
 
 .participant {
@@ -71,7 +82,7 @@ const participantNum = computed(() => {
 }
 
 .participant__num > span {
-  margin-right: .5rem;
+  margin-right: 0.5rem;
   font-weight: bold;
 }
 
@@ -86,25 +97,25 @@ const participantNum = computed(() => {
   width: 220px;
   height: 46px;
   border-radius: 1.625rem;
-  display: flex; 
+  display: flex;
   flex-grow: 0;
   cursor: pointer;
   align-items: center;
   padding-left: 6px;
 }
 
-.participant__info:hover{
+.participant__info:hover {
   background-color: var(--main-color);
   color: var(--white);
 }
 
-.participant__info > img{
+.participant__info > img {
   width: 36px;
   height: 36px;
   margin-right: 15px;
 }
 
-@media (min-width:576px){
+@media (min-width: 576px) {
   .participant__list {
     display: grid;
     grid-auto-rows: 52px;
@@ -117,13 +128,13 @@ const participantNum = computed(() => {
     font-size: 18px;
     font-weight: 500;
   }
-  
+
   .participant__info {
     width: 240px;
     height: 52px;
   }
-  
-  .participant__info > img{
+
+  .participant__info > img {
     width: 42px;
     height: 42px;
   }
@@ -132,19 +143,18 @@ const participantNum = computed(() => {
     font-size: 18px;
   }
 
-  .main{
-        margin: 5rem auto;
+  .main {
+    margin: 5rem auto;
   }
 
   .main > section {
-        margin: 2rem 20px;
+    margin: 2rem 20px;
   }
 }
 
-@media (min-width:792px){
+@media (min-width: 792px) {
   .participant__list {
     grid-template-columns: repeat(3, 240px);
   }
 }
-
 </style>

--- a/src/main/vue/src/components/meeting/article/Article.vue
+++ b/src/main/vue/src/components/meeting/article/Article.vue
@@ -119,6 +119,17 @@ async function onClickLeaveBtn() {
   currentControlType.value = controlType[1];
   controlModalOn.value = !controlModalOn.value;
 }
+
+async function onClickCloseBtn() {
+  const isLoggedIn = await memberStore.isAuthenticated();
+  if (!isLoggedIn) {
+    loginModalStore.handleModal();
+    return;
+  }
+
+  currentControlType.value = controlType[2];
+  controlModalOn.value = !controlModalOn.value;
+}
 </script>
 
 <style>

--- a/src/main/vue/src/components/meeting/article/Article.vue
+++ b/src/main/vue/src/components/meeting/article/Article.vue
@@ -2,63 +2,70 @@
   <article>
     <header>
       <div class="category-wrap">
-        <span class="category">{{ article.categoryName }}</span>
+        <span class="category">{{ meetingDetailStore.categoryName }}</span>
       </div>
       <div class="title-container">
-        <h2 class="title">{{ article.title }}</h2>
+        <h2 class="title">{{ meetingDetailStore.title }}</h2>
         <span class="kebab icon icon-kebab"></span>
         <img src="" alt="" />
       </div>
 
       <div class="start-datetime-container">
         <span class="icon icon-calender16"></span>
-        <span>{{ article.textStartedAt }}</span>
+        <span>{{ meetingDetailStore.textStartedAt }}</span>
       </div>
       <div class="region-container">
         <span class="icon-location16"></span>
 
-        <span>{{ article.region }}</span>
-        <span>{{ article.regionName }}</span>
+        <span>{{ meetingDetailStore.region }}</span>
+        <span>{{ meetingDetailStore.regionName }}</span>
       </div>
       <div class="region-detail-wrap">
-        <span>{{ article.detailRegion }}</span>
+        <span>{{ meetingDetailStore.detailRegion }}</span>
       </div>
     </header>
 
     <div class="content-container">
-      <span v-html="article.content"></span>
+      <span v-html="meetingDetailStore.content"></span>
       <ul class="tags">
-        <li>#{{ article.ageRange }} 선호</li>
-        <li>#{{ article.maxMember }} 명</li>
-        <li>#{{ article.genderCategory }}</li>
+        <li>#{{ meetingDetailStore.ageRange }} 선호</li>
+        <li>#{{ meetingDetailStore.maxMember }} 명</li>
+        <li>#{{ meetingDetailStore.genderCategory }}</li>
       </ul>
-      <div class="views">조회수 {{ article.viewCount }}회</div>
+      <div class="views">조회수 {{ meetingDetailStore.viewCount }}회</div>
       <div class="control-btn-wrap">
-        <Round v-if="article.myMeeting && !article.closed">
+        <Round
+          v-if="meetingDetailStore.myMeeting && !meetingDetailStore.closed"
+          @click.prevent="onClickCloseBtn"
+        >
           <template #content> 마감하기 </template>
         </Round>
         <Round
           v-else-if="
-            !article.myMeeting && !article.hasParticipated && !article.closed
+            !meetingDetailStore.myMeeting &&
+            !meetingDetailStore.hasParticipated &&
+            !meetingDetailStore.closed
           "
           @click.prevent="onClickParticipationBtn"
         >
           <template #content> 참여하기 </template>
         </Round>
         <Round
-          v-else-if="!article.myMeeting && article.hasParticipated"
+          v-else-if="
+            !meetingDetailStore.myMeeting && meetingDetailStore.hasParticipated
+          "
           @click.prevent="onClickLeaveBtn"
         >
           <template #content> 참여취소 </template>
         </Round>
-        <RoundDisabled v-else-if="article.closed">
+        <RoundDisabled v-else-if="meetingDetailStore.closed">
           <template #content> 모집완료 </template>
         </RoundDisabled>
       </div>
       <ControlModal
         v-if="controlModalOn"
         :controlType="currentControlType"
-        :articleTitle="article.title"
+        :articleTitle="meetingDetailStore.title"
         @closeModal="closeControlModal"
         @refresh="emit('refresh')"
       ></ControlModal>
@@ -70,16 +77,15 @@
 import { ref } from "vue";
 import { useMemberStore } from "@/stores/memberStore";
 import { useLoginModalStore } from "@/stores/loginModalStore";
+import { useMeetingDetailStore } from "@/stores/meetingDetailStore";
 import Round from "@/components/button/Round.vue";
 import RoundDisabled from "@/components/button/RoundDisabled.vue";
 import ControlModal from "./ControlModal.vue";
 
 const memberStore = useMemberStore();
 const loginModalStore = useLoginModalStore();
+const meetingDetailStore = useMeetingDetailStore();
 
-const props = defineProps({
-  article: Object,
-});
 // refresh : 모임 상세 조회 최신화
 const emit = defineEmits(["refresh"]);
 

--- a/src/main/vue/src/components/meeting/article/ControlModal.vue
+++ b/src/main/vue/src/components/meeting/article/ControlModal.vue
@@ -2,14 +2,16 @@
 import { ref } from "vue";
 import { useRoute } from "vue-router";
 import api from "@/api";
+import { useMeetingDetailStore } from "@/stores/meetingDetailStore";
 import ModalDefault from "@/components/modal/Default.vue";
 import { ServerException } from "@/utils/ServerException";
+
+const meetingDetailStore = useMeetingDetailStore();
 
 const route = useRoute();
 
 const props = defineProps({
   controlType: String,
-  articleTitle: String,
 });
 
 // refresh : 모임 상세 조회 최신화
@@ -24,6 +26,9 @@ async function onClickYes() {
       break;
     case "참여취소":
       await leave();
+      break;
+    case "마감":
+      await close();
       break;
   }
 }
@@ -51,6 +56,18 @@ async function leave() {
   } catch (e) {}
 }
 
+async function close() {
+  try {
+    const res = await api.meeting.close(route.params.id);
+    if (!res.ok) throw new ServerException(res);
+    const data = await res.json();
+
+    confirmMsg.value = "모임을 마감했어요 !";
+    closeModalFooterType();
+    meetingDetailStore.closed = true;
+  } catch (e) {}
+}
+
 let modalFooterType = ref(0);
 
 function closeModalFooterType() {
@@ -61,22 +78,27 @@ function closeModalFooterType() {
 <template>
   <ModalDefault @closeModal="emit('closeModal')">
     <template v-if="props.controlType === '참여'" #modal-body>
-      <p>🤝 {{ props.articleTitle }}</p>
+      <p>🤝 {{ meetingDetailStore.title }}</p>
       <p class="confirm">모임에 참여하시겠어요?</p>
     </template>
     <template v-else-if="props.controlType === '참여취소'" #modal-body>
       <div v-if="!confirmMsg">
-        <p>🤝 {{ props.articleTitle }}</p>
+        <p>🤝 {{ meetingDetailStore.title }}</p>
         <p class="confirm">참여를 취소하시겠어요?</p>
       </div>
       <div v-else>
-        <p>🤝 {{ props.articleTitle }}</p>
+        <p>🤝 {{ meetingDetailStore.title }}</p>
         <p class="confirm">{{ confirmMsg }}</p>
       </div>
     </template>
-    <template v-else-if="props.controlType === '마감'" #modal-body
-      >마감</template
-    >
+    <template v-else-if="props.controlType === '마감'" #modal-body>
+      <div v-if="!confirmMsg">
+        <p class="confirm">모임을 마감하시겠어요?</p>
+      </div>
+      <div v-else>
+        <p class="confirm">{{ confirmMsg }}</p>
+      </div>
+    </template>
     <template v-else="props.controlType === '참여링크'" #modal-body
       >참여링크</template
     >

--- a/src/main/vue/src/stores/meetingDetailStore.js
+++ b/src/main/vue/src/stores/meetingDetailStore.js
@@ -1,0 +1,54 @@
+import { defineStore } from "pinia";
+
+/**
+ * 모임 상세 조회
+ */
+export const useMeetingDetailStore = defineStore("meetingDetail", {
+  state: () => ({
+    id: null,
+    regMemberId: null,
+    title: "",
+    content: "",
+    ageRange: "",
+    categoryName: "",
+    genderCategory: "",
+    regionName: "",
+    detailRegion: "",
+    maxMember: 0,
+    startedAt: "",
+    textStartedAt: "",
+    viewCount: 0,
+    closed: null,
+    participants: [],
+    commentCount: 0,
+    comments: [],
+    myMeeting: false,
+    hasParticipated: false,
+  }),
+  actions: {
+    init(data) {
+      this.id = data.id || null;
+      this.regMemberId = data.regMemberId || null;
+      this.title = data.title || "";
+      this.content = data.content || "";
+      this.ageRange = data.ageRange || "";
+      this.categoryName = data.categoryName || "";
+      this.genderCategory = data.genderCategory || "";
+      this.regionName = data.regionName || "";
+      this.detailRegion = data.detailRegion || "";
+      this.maxMember = data.maxMember || 0;
+      this.startedAt = data.startedAt || "";
+      this.textStartedAt = data.textStartedAt || "";
+      this.viewCount = data.viewCount || 0;
+      this.closed = data.closed || null;
+      this.participants = data.participants || [];
+      this.commentCount = data.commentCount || 0;
+      this.comments = data.comments || [];
+      this.myMeeting = data.myMeeting || false;
+      this.hasParticipated = data.hasParticipated || false;
+    },
+    increaseCommentCount() {
+      this.commentCount++;
+    },
+  },
+});

--- a/src/main/vue/src/views/meeting/Detail.vue
+++ b/src/main/vue/src/views/meeting/Detail.vue
@@ -1,27 +1,27 @@
 <!-- detail vue = 화면 / article 화면의 구성 요소중 한 부분-->
 <script setup>
-import { reactive, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { useMeetingDetailStore } from "@/stores/meetingDetailStore";
 import api from "@/api"; //index.js
 import Article from "@/components/meeting/article/Article.vue";
 import Participants from "@/components/meeting/Participants.vue";
 import CommentList from "@/components/comment/CommentList.vue";
 import { ServerException } from "@/utils/ServerException";
 
-const state = reactive({
-  detail: {},
-});
 // 모임 정보 조회 reactive는 view단과 model단 일치
 const route = useRoute();
 const router = useRouter();
+const detailStore = useMeetingDetailStore();
+detailStore.$reset();
 
 const getDetail = async () => {
   try {
     const res = await api.meeting.getDetail(route.params.id);
     if (!res.ok) throw new ServerException(res);
     const data = await res.json();
-    state.detail = data;
+    detailStore.init(data);
   } catch (e) {
+    console.log(e);
     // 존재하지 않는 meeting id
     if (e.res.status === 404) router.push("/404");
   }
@@ -32,20 +32,12 @@ getDetail();
 const newComment = async () => {
   await getDetail(route.params.id);
 };
-
-function increaseCounter() {
-  state.detail.commentCount++;
-}
 </script>
 <template>
   <div class="content-wrap">
-    <Article :article="state.detail" @refresh="getDetail" />
-    <Participants :detail="state.detail" />
-    <CommentList
-      :detail="state.detail"
-      @newComment="newComment"
-      @counterIncreased="increaseCounter"
-    />
+    <Article @refresh="getDetail" />
+    <Participants />
+    <CommentList @newComment="newComment" />
   </div>
 </template>
 <style scoped>


### PR DESCRIPTION
## 🛠 작업사항
### meetingDetail store 추가
[feat: meetingDetailStore](https://github.com/Z-P0P/ZPOP/commit/6e442fd8910d696e2d9809c049123822fd20ece7)

Detail.vue에서 모임 정보, 참여자 리스트, 댓글리스트에 대해 props으로 전달하고 있었는데, model 최신화 + 화면 재렌더링 하기가 껄끄러웠음
따라서 meetingDetail store 추가 하여 해결함
모임 정보, 참여자 리스트, 댓글 리스트에 반영하였음
### 모임 마감하기 구현
모임 마감하기를 구현 함
![화면 기록 2023-01-23 오후 3 51 09](https://user-images.githubusercontent.com/105474635/213981063-a28e9f9d-e7fe-402c-8768-d45e2105653f.gif)

