### PR TITLE
refactor: 모임 참여 취소

### DIFF
--- a/src/main/vue/src/components/meeting/article/Article.vue
+++ b/src/main/vue/src/components/meeting/article/Article.vue
@@ -67,7 +67,6 @@
         :controlType="currentControlType"
         :articleTitle="meetingDetailStore.title"
         @closeModal="closeControlModal"
-        @refresh="emit('refresh')"
       ></ControlModal>
     </div>
   </article>
@@ -85,9 +84,6 @@ import ControlModal from "./ControlModal.vue";
 const memberStore = useMemberStore();
 const loginModalStore = useLoginModalStore();
 const meetingDetailStore = useMeetingDetailStore();
-
-// refresh : 모임 상세 조회 최신화
-const emit = defineEmits(["refresh"]);
 
 // 참여, 마감, 참여취소, 링크 모달 on/off
 let controlModalOn = ref(false);

--- a/src/main/vue/src/components/meeting/article/ControlModal.vue
+++ b/src/main/vue/src/components/meeting/article/ControlModal.vue
@@ -2,11 +2,13 @@
 import { ref } from "vue";
 import { useRoute } from "vue-router";
 import api from "@/api";
+import { useMemberStore } from "@/stores/memberStore";
 import { useMeetingDetailStore } from "@/stores/meetingDetailStore";
 import ModalDefault from "@/components/modal/Default.vue";
 import { ServerException } from "@/utils/ServerException";
 
 const meetingDetailStore = useMeetingDetailStore();
+const memberStore = useMemberStore();
 
 const route = useRoute();
 
@@ -52,8 +54,11 @@ async function leave() {
 
     confirmMsg.value = "모임 참여를 취소했어요 !";
     closeModalFooterType();
-    emit("refresh");
-  } catch (e) {}
+    meetingDetailStore.removeParticipant(memberStore.id);
+    meetingDetailStore.hasParticipated = false;
+  } catch (e) {
+    console.log(e)
+  }
 }
 
 async function close() {

--- a/src/main/vue/src/stores/meetingDetailStore.js
+++ b/src/main/vue/src/stores/meetingDetailStore.js
@@ -50,5 +50,10 @@ export const useMeetingDetailStore = defineStore("meetingDetail", {
     increaseCommentCount() {
       this.commentCount++;
     },
+    removeParticipant(removeTargetId) {
+      this.participants = this.participants.filter(
+        (p) => p.participantId !== removeTargetId
+      );
+    },
   },
 });


### PR DESCRIPTION
## 🛠 작업사항
- 모임 참여 취소후, 화면의 참여자 리스트를 재 렌더링하기위해 get detail api를 호출함
- 이는 매번 조회수가 오르는 문제가 있어서 수정함
### 수정 전
https://github.com/Z-P0P/ZPOP/pull/149
### 수정 후
![화면 기록 2023-01-23 오후 4 23 21](https://user-images.githubusercontent.com/105474635/213985864-7bd7738e-ff5e-47da-a3fc-14c2e97547a9.gif)

