### PR TITLE
[FEAT] 관리자 페이지 추가 & 관리자 신고 기능 추가

### DIFF
--- a/src/main/java/com/zpop/web/controller/admin/ReportController.java
+++ b/src/main/java/com/zpop/web/controller/admin/ReportController.java
@@ -1,83 +1,130 @@
 package com.zpop.web.controller.admin;
 
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.zpop.web.dto.admin.AdminReportedCommentDto;
 import com.zpop.web.dto.admin.AdminReportedMeetingDto;
 import com.zpop.web.dto.admin.AdminReportedMemberDto;
 import com.zpop.web.service.admin.AdminReportService;
 
-@Controller("adminReportController")
-@RequestMapping("/admin/report")
+@RequestMapping("/api/admin/report")
+@RestController("adminReportController")
 public class ReportController {
 
 	private final AdminReportService adminReportService;
-	
+
 	@Autowired
-	public ReportController (AdminReportService adminReportService) {
+	public ReportController(AdminReportService adminReportService) {
 		this.adminReportService = adminReportService;
 	}
-	
+
 	@GetMapping()
 	public String member() {
 		return "redirect:report/member?p=1";
 	}
-	
-	
+
 	@GetMapping("member")
-	public String getReportedMemberList(Model model
-			,@RequestParam(name="p", defaultValue="1") int page
-			,@RequestParam @Nullable String keyword
-			,@RequestParam @Nullable String option) {
+	public Map<String,Object> getReportedMemberList(
+		@RequestParam(name="page", defaultValue="1") int page
+		,@RequestParam @Nullable String keyword
+		,@RequestParam @Nullable Integer period
+		,@RequestParam @Nullable @DateTimeFormat(iso=ISO.DATE) Date minDate
+		,@RequestParam (name="option", defaultValue = "nickname") String option
+		,@RequestParam(name="num", defaultValue="10") Integer num
+		,@RequestParam(name="order", defaultValue="desc") String order) {
+		List<AdminReportedMemberDto> reportedMembers = adminReportService.getReportedMembers (page, keyword, option, minDate, period, num, order);
+		int count = adminReportService.countReportedMembers(keyword, option, minDate, period);
+		Map<String,Object> result = new HashMap<>();
+		result.put("reportedMembers",reportedMembers);
+		result.put("count", count);
 		
-		List<AdminReportedMemberDto> reportedMembers = 
-					adminReportService.getReportedMembers (page,keyword,option);
-		int count = adminReportService.countReportedMembers(keyword, option);
-		model.addAttribute("reportedMembers", reportedMembers);
-		model.addAttribute("count",count);
-		model.addAttribute("page",page);
-		
-		return "admin/report/member";
+		return result;
 	}
-	
+
 	@GetMapping("meeting")
-	public String getReportedMeetingList(Model model
-			,@RequestParam(name="p", defaultValue="1") int page
-			,@RequestParam @Nullable String keyword
-			,@RequestParam @Nullable String option) {
-		
-		List<AdminReportedMeetingDto> reportedMeetings = 
-					adminReportService.getReportedMeetings (page,keyword,option);
-		int count = adminReportService.countReportedMeetings(keyword, option);
-		model.addAttribute("reportedMeetings", reportedMeetings);
-		model.addAttribute("count",count);
-		model.addAttribute("page",page);
-		
-		return "admin/report/meeting";
+	public Map<String,Object> getReportedMeetingList(
+	@RequestParam(name="page", defaultValue="1") int page
+	,@RequestParam @Nullable String keyword
+	,@RequestParam @Nullable Integer period
+	,@RequestParam @Nullable @DateTimeFormat(iso=ISO.DATE) Date minDate
+	,@RequestParam (name="option", defaultValue = "title") String option
+	,@RequestParam(name="num", defaultValue="10") Integer num
+	,@RequestParam(name="order", defaultValue="desc") String order) {
+
+		List<AdminReportedMeetingDto> reportedMeetings = adminReportService.getReportedMeetings(page, keyword, option, minDate, period,num,order);
+		int count = adminReportService.countReportedMeetings(keyword, option, minDate, period);
+		Map<String,Object> result = new HashMap<>();
+		result.put("reportedMeetings",reportedMeetings);
+		result.put("count", count);
+
+		return result;
 	}
-	
+
 	@GetMapping("comment")
-	public String getReportedCommentList(Model model
-			,@RequestParam(name="p", defaultValue="1") int page
-			,@RequestParam @Nullable String keyword
-			,@RequestParam @Nullable String option) {
-		
-		List<AdminReportedCommentDto> reportedComments = 
-					adminReportService.getReportedComments (page,keyword,option);
-		int count = adminReportService.countReportedComments(keyword, option);
-		model.addAttribute("reportedComments", reportedComments);
-		model.addAttribute("count",count);
-		model.addAttribute("page",page);
-		
-		return "admin/report/comment";
+	public Map<String,Object> getReportedCommentList(
+		@RequestParam(name="page", defaultValue="1") int page
+		,@RequestParam @Nullable String keyword
+		,@RequestParam @Nullable Integer period
+		,@RequestParam @Nullable @DateTimeFormat(iso=ISO.DATE) Date minDate
+		,@RequestParam (name="option", defaultValue = "original") String option
+		,@RequestParam(name="num", defaultValue="10") Integer num
+		,@RequestParam(name="order", defaultValue="desc") String order) {
+		List<AdminReportedCommentDto> reportedComments = adminReportService.getReportedComments(page, keyword, option, minDate, period, num,order);
+		int count = adminReportService.countReportedComments(keyword, option, minDate, period);
+		Map<String,Object> result = new HashMap<>();
+		result.put("reportedComments",reportedComments);
+		result.put("count", count);
+
+		return result;
 	}
-	
+
+	@DeleteMapping("member")
+	public int cancelMemberReport(@RequestParam List<Integer> ids){
+		int result = adminReportService.cancelMemberReport(ids);
+		return result;
+	}
+
+	@DeleteMapping("meeting")
+	public int cancelMeetingReport(@RequestParam List<Integer> ids){
+		int result = adminReportService.cancelMeetingReport(ids);
+		return result;
+	}
+
+	@DeleteMapping("comment")
+	public int cancelCommentReport(@RequestParam List<Integer> ids){
+		int result = adminReportService.cancelCommentReport(ids);
+		return result;
+	}
+
+	@PutMapping("member")
+	public int suspendMemberReported(@RequestParam List<Integer> ids, @RequestParam Integer period){
+		int result = adminReportService.suspendMemberReported(ids,period);
+		return result;
+	}
+
+	@PutMapping("meeting")
+	public int suspendMeetingReported(@RequestParam List<Integer> ids, @RequestParam Integer period){
+		int result = adminReportService.suspendMeetingReported(ids,period);
+		return result;
+	}
+
+	@PutMapping("comment")
+	public int suspendCommentReported(@RequestParam List<Integer> ids, @RequestParam Integer period){
+		int result = adminReportService.suspendCommentReported(ids,period);
+		return result;
+	}
 }

--- a/src/main/java/com/zpop/web/dao/CommentDao.java
+++ b/src/main/java/com/zpop/web/dao/CommentDao.java
@@ -1,7 +1,11 @@
 package com.zpop.web.dao;
 
+import java.util.Date;
 import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
+
+import com.zpop.web.dto.admin.AdminCommentDto;
 import com.zpop.web.entity.comment.Comment;
 import com.zpop.web.entity.comment.CommentView;
 /*
@@ -28,6 +32,13 @@ public interface CommentDao {
 	int updateComment(int commentId, String content);
 	int deleteComment(int commentId); //레코드에 삭제날짜를 설정. 실제 삭제 x
 
+	List<AdminCommentDto> getAdminList(int offset, int size, String keyword, String option, Date minDate, Integer period, String order);
+	
+	int countBySearch(String keyword, String option, Date minDate, Integer period);
 
+	List<Comment> getByIds(List<Integer> ids);
 
+	int removeAllDeletedAt(List<Integer> ids);
+
+	int updateAllDeletedAt(List<Integer> ids);
 }

--- a/src/main/java/com/zpop/web/dao/MeetingDao.java
+++ b/src/main/java/com/zpop/web/dao/MeetingDao.java
@@ -10,6 +10,7 @@ import com.zpop.web.entity.meeting.Meeting;
 import com.zpop.web.entity.meeting.MeetingThumbnailView;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.Date;
 import java.util.List;
 
 @Mapper
@@ -30,9 +31,9 @@ public interface MeetingDao {
 
 	List<ParticipantDto> getParticipants(int id);
 
-	List<AdminMeetingDto> getAdminViewList(int size, int offset, String keyword, String option);
+	List<AdminMeetingDto> getAdminViewList(int size, int offset, String keyword, String option, Integer period, Date minDate, String order);
 
-	int count(String keyword, String option);
+	int count(String keyword, String option, Integer period, Date minDate);
 
 	int updateClosedAt(Meeting meeting);
 
@@ -51,5 +52,14 @@ public interface MeetingDao {
 	UpdateMeetingViewDto getUpdateView(int id);
 
 	int getCountOfComment(int meetingId);
+
+    int removeDeletedAt(Meeting meeting);
+
+    int updateAllDeletedAt(List<Integer> ids);
+
+    int removeAllDeletedAt(List<Integer> ids);
+
+	List<Meeting> getByIds(List<Integer> ids);
+
 }
 

--- a/src/main/java/com/zpop/web/dao/MemberDao.java
+++ b/src/main/java/com/zpop/web/dao/MemberDao.java
@@ -6,6 +6,7 @@ import com.zpop.web.entity.MemberEval;
 import com.zpop.web.entity.member.MyMeetingView;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.Date;
 import java.util.List;
 
 @Mapper
@@ -23,14 +24,16 @@ public interface MemberDao {
 	int insert(Member member);
 
 	int update(Member member);
-	int countBySearch(String keyword, String option);
+	int countBySearch(String keyword, String option, Integer period, Date minDate);
 	int count(int socialTypeId);
 
 
-	List<Member> getListBySearch(int size, int offset, String keyword, String option);
+	List<Member> getListBySearch(int size, int offset, String keyword, String option, Integer period, Date minDate, String order);
 	List<MyMeetingView> getMyMeeting(int memberId);
 	List<MyMeetingView> getMyGathering(int memberId);
 
 	List<EvalMemberDto> getEvalMember(int meetingId);
 	int updateFameAll(List<MemberEval> evals);
+
+    int updateAllIsSuspended(List<Integer> ids, Boolean isSuspended);
 }

--- a/src/main/java/com/zpop/web/dao/ReportedCommentDao.java
+++ b/src/main/java/com/zpop/web/dao/ReportedCommentDao.java
@@ -1,5 +1,6 @@
 package com.zpop.web.dao;
 
+import java.util.Date;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -11,12 +12,15 @@ import com.zpop.web.entity.Notification;
 @Mapper
 public interface ReportedCommentDao {
 
-	List<AdminReportedCommentDto> getAdminViewList(int size, int offset, Object object, Object object2);
+	List<AdminReportedCommentDto> getAdminViewList(int size, int offset, String keyword, String option, Date minDate, Integer period, String order);
 
-	int count(String keyword, String option);
+	int count(String keyword, String option, Date minDate, Integer period);
 	
 	int insert(ReportedComment reportedComment);
 	
 	int[] select(int commentId, int reporterId);
+
+    int updateAll(List<Integer> ids, Date releasedAt);
 	
+	List<ReportedComment> getByIds(List<Integer> ids);
 }

--- a/src/main/java/com/zpop/web/dao/ReportedMeetingDao.java
+++ b/src/main/java/com/zpop/web/dao/ReportedMeetingDao.java
@@ -1,5 +1,6 @@
 package com.zpop.web.dao;
 
+import java.util.Date;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -10,12 +11,16 @@ import com.zpop.web.dto.admin.AdminReportedMeetingDto;
 @Mapper
 public interface ReportedMeetingDao {
 
-	List<AdminReportedMeetingDto> getAdminViewList(int size, int offset, Object object, Object object2);
+	List<AdminReportedMeetingDto> getAdminViewList(int size, int offset, String keyword, String option, Date minDate, Integer period, String order);
 
-	int count(String keyword, String option);
+	int count(String keyword, String option, Date minDate, Integer period);
 	
 	int insert(ReportedMeeting reportedMeeting);
 	
 	int[] getReportedMeetingId(int meetingId, int reporterId);
+
+	int updateAll(List<Integer> ids, Date releasedAt);
+
+	List<ReportedMeeting> getByIds(List<Integer> ids);
 	
 }

--- a/src/main/java/com/zpop/web/dao/ReportedMemberDao.java
+++ b/src/main/java/com/zpop/web/dao/ReportedMemberDao.java
@@ -1,20 +1,23 @@
 package com.zpop.web.dao;
 
+import java.util.Date;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
-import com.zpop.web.entity.ReportedMember;
 import com.zpop.web.dto.admin.AdminReportedMemberDto;
-import com.zpop.web.entity.Notification;
+import com.zpop.web.entity.ReportedMember;
 
 @Mapper
 public interface ReportedMemberDao {
 
-	List<AdminReportedMemberDto> getAdminViewList(int size, int offset, Object object, Object object2);
+	List<AdminReportedMemberDto> getAdminViewList(int size, int offset, String keyword, String option, Date minDate, Integer period, String order);
 
-	int count(String keyword, String option);
+	int count(String keyword, String option, Date minDate, Integer period);
 	
 	int insert(ReportedMember reportedMember);
 	
+	int updateAll(List<Integer> ids, Date releasedAt);
+
+    List<ReportedMember> getByIds(List<Integer> ids);
 }

--- a/src/main/java/com/zpop/web/dto/admin/AdminReportedCommentDto.java
+++ b/src/main/java/com/zpop/web/dto/admin/AdminReportedCommentDto.java
@@ -1,7 +1,22 @@
 package com.zpop.web.dto.admin;
 
-import java.sql.Date;
+import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
 public class AdminReportedCommentDto {
 	
 	private int id;
@@ -11,53 +26,8 @@ public class AdminReportedCommentDto {
 	private String writerNickname;
 	private int writerId;
 	private String reportType;
+	private String reason;
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private Date createdAt;
 	private Date processedAt;
-	public int getId() {
-		return id;
-	}
-	public void setId(int id) {
-		this.id = id;
-	}
-	public String getReporterNickname() {
-		return reporterNickname;
-	}
-	public void setReporterNickname(String reporterNickname) {
-		this.reporterNickname = reporterNickname;
-	}
-	public int getReporterId() {
-		return reporterId;
-	}
-	public void setReporterId(int reporterId) {
-		this.reporterId = reporterId;
-	}
-	public String getOriginal() {
-		return original;
-	}
-	public void setOriginal(String original) {
-		this.original = original;
-	}
-	public String getWriterNickname() {
-		return writerNickname;
-	}
-	public void setWriterNickname(String writerNickname) {
-		this.writerNickname = writerNickname;
-	}
-	public int getWriterId() {
-		return writerId;
-	}
-	public void setWriterId(int writerId) {
-		this.writerId = writerId;
-	}
-	public String getReportType() {
-		return reportType;
-	}
-	public void setReportType(String reportType) {
-		this.reportType = reportType;
-	}
-	public Date getProcessedAt() {
-		return processedAt;
-	}
-	public void setProcessedAt(Date processedAt) {
-		this.processedAt = processedAt;
-	}
 }

--- a/src/main/java/com/zpop/web/dto/admin/AdminReportedMeetingDto.java
+++ b/src/main/java/com/zpop/web/dto/admin/AdminReportedMeetingDto.java
@@ -1,7 +1,22 @@
 package com.zpop.web.dto.admin;
 
-import java.sql.Date;
+import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
 public class AdminReportedMeetingDto {
 	
 	private int id;
@@ -11,54 +26,8 @@ public class AdminReportedMeetingDto {
 	private String writerNickname;
 	private int writerId;
 	private String reportType;
+	private String reason;
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private Date createdAt;
 	private Date processedAt;
-	
-	public int getId() {
-		return id;
-	}
-	public void setId(int id) {
-		this.id = id;
-	}
-	public String getReporterNickname() {
-		return reporterNickname;
-	}
-	public void setReporterNickname(String reporterNickname) {
-		this.reporterNickname = reporterNickname;
-	}
-	public int getReporterId() {
-		return reporterId;
-	}
-	public void setReporterId(int reporterId) {
-		this.reporterId = reporterId;
-	}
-	public String getMeetingTitle() {
-		return meetingTitle;
-	}
-	public void setMeetingTitle(String meetingTitle) {
-		this.meetingTitle = meetingTitle;
-	}
-	public String getWriterNickname() {
-		return writerNickname;
-	}
-	public void setWriterNickname(String writerNickname) {
-		this.writerNickname = writerNickname;
-	}
-	public int getWriterId() {
-		return writerId;
-	}
-	public void setWriterId(int writerId) {
-		this.writerId = writerId;
-	}
-	public String getReportType() {
-		return reportType;
-	}
-	public void setReportType(String reportType) {
-		this.reportType = reportType;
-	}
-	public Date getProcessedAt() {
-		return processedAt;
-	}
-	public void setProcessedAt(Date processedAt) {
-		this.processedAt = processedAt;
-	}
 }

--- a/src/main/java/com/zpop/web/dto/admin/AdminReportedMemberDto.java
+++ b/src/main/java/com/zpop/web/dto/admin/AdminReportedMemberDto.java
@@ -1,7 +1,22 @@
 package com.zpop.web.dto.admin;
 
-import java.sql.Date;
+import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
 public class AdminReportedMemberDto {
 	
 	private int id;
@@ -10,49 +25,9 @@ public class AdminReportedMemberDto {
 	private String reportedNickname;
 	private int reportedId;
 	private String reportType;
+	private String reason;
+	@JsonFormat(pattern = "yyyy-MM-dd")
+	private Date createdAt;
 	private Date processedAt;
-	
-	public int getId() {
-		return id;
-	}
-	public void setId(int id) {
-		this.id = id;
-	}
-	public String getReporterNickname() {
-		return reporterNickname;
-	}
-	public void setReporterNickname(String reporterNickname) {
-		this.reporterNickname = reporterNickname;
-	}
-	public int getReporterId() {
-		return reporterId;
-	}
-	public void setReporterId(int reporterId) {
-		this.reporterId = reporterId;
-	}
-	public String getReportedNickname() {
-		return reportedNickname;
-	}
-	public void setReportedNickname(String reportedNickname) {
-		this.reportedNickname = reportedNickname;
-	}
-	public int getReportedId() {
-		return reportedId;
-	}
-	public void setReportedId(int reportedId) {
-		this.reportedId = reportedId;
-	}
-	public String getReportType() {
-		return reportType;
-	}
-	public void setReportType(String reportType) {
-		this.reportType = reportType;
-	}
-	public Date getProcessedAt() {
-		return processedAt;
-	}
-	public void setProcessedAt(Date processedAt) {
-		this.processedAt = processedAt;
-	}
 	
 }

--- a/src/main/java/com/zpop/web/service/admin/AdminReportService.java
+++ b/src/main/java/com/zpop/web/service/admin/AdminReportService.java
@@ -1,5 +1,6 @@
 package com.zpop.web.service.admin;
 
+import java.util.Date;
 import java.util.List;
 
 import com.zpop.web.dto.admin.AdminReportedCommentDto;
@@ -8,16 +9,28 @@ import com.zpop.web.dto.admin.AdminReportedMemberDto;
 
 public interface AdminReportService {
 
-	List<AdminReportedMemberDto> getReportedMembers(int page, String keyword, String option);
+	List<AdminReportedMemberDto> getReportedMembers(int page, String keyword, String option, Date minDate, Integer period, Integer num, String order);
 
-	List<AdminReportedCommentDto> getReportedComments(int page, String keyword, String option);
+	List<AdminReportedCommentDto> getReportedComments(int page, String keyword, String option, Date minDate, Integer period, Integer num, String order);
 	
-	List<AdminReportedMeetingDto> getReportedMeetings(int page, String keyword, String option);
+	List<AdminReportedMeetingDto> getReportedMeetings(int page, String keyword, String option, Date minDate, Integer period, Integer num, String order);
 	
-	int countReportedMembers(String keyword, String option);
+	int countReportedMembers(String keyword, String option, Date minDate, Integer period);
 
-	int countReportedComments(String keyword, String option);
+	int countReportedComments(String keyword, String option, Date minDate, Integer period);
 
-	int countReportedMeetings(String keyword, String option);
+	int countReportedMeetings(String keyword, String option, Date minDate, Integer period);
+
+    int cancelMemberReport(List<Integer> ids);
+
+    int cancelMeetingReport(List<Integer> ids);
+
+    int cancelCommentReport(List<Integer> ids);
+
+	int suspendMemberReported(List<Integer> ids, Integer period);
+
+    int suspendMeetingReported(List<Integer> ids, Integer period);
+
+    int suspendCommentReported(List<Integer> ids, Integer period);
 
 }

--- a/src/main/java/com/zpop/web/service/admin/DefaultAdminReportService.java
+++ b/src/main/java/com/zpop/web/service/admin/DefaultAdminReportService.java
@@ -1,76 +1,283 @@
 package com.zpop.web.service.admin;
 
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.zpop.web.dao.CommentDao;
+import com.zpop.web.dao.MeetingDao;
+import com.zpop.web.dao.MemberDao;
 import com.zpop.web.dao.ReportedCommentDao;
 import com.zpop.web.dao.ReportedMeetingDao;
 import com.zpop.web.dao.ReportedMemberDao;
 import com.zpop.web.dto.admin.AdminReportedCommentDto;
 import com.zpop.web.dto.admin.AdminReportedMeetingDto;
 import com.zpop.web.dto.admin.AdminReportedMemberDto;
+import com.zpop.web.entity.ReportedComment;
+import com.zpop.web.entity.ReportedMeeting;
+import com.zpop.web.entity.ReportedMember;
+import com.zpop.web.entity.comment.Comment;
+import com.zpop.web.entity.meeting.Meeting;
 
 @Service
 public class DefaultAdminReportService implements AdminReportService{
 
-	private final ReportedMemberDao reportedMemberDao;
-	private final ReportedMeetingDao reportedMeetingDao;
-	private final ReportedCommentDao reportedCommentDao;
-	
 	@Autowired
-	public DefaultAdminReportService (ReportedMemberDao reportedMemberDao,
-								ReportedMeetingDao reportedMeetingDao,
-								ReportedCommentDao reportedCommentDao) {
-		this.reportedMemberDao = reportedMemberDao;
-		this.reportedMeetingDao = reportedMeetingDao;
-		this.reportedCommentDao = reportedCommentDao;
-	}
-	
+	private ReportedMemberDao reportedMemberDao;
+	@Autowired
+	private ReportedMeetingDao reportedMeetingDao;
+	@Autowired
+	private ReportedCommentDao reportedCommentDao;
+	@Autowired
+	private MemberDao memberDao;
+	@Autowired
+	private MeetingDao meetingDao;
+	@Autowired
+	private CommentDao commentDao;
+
 	@Override
-	public List<AdminReportedMemberDto> getReportedMembers(int page, String keyword, String option) {
-		int size = 10;
-		int offset=(page-1)*size;
-		List<AdminReportedMemberDto> list = reportedMemberDao.getAdminViewList(size, offset, keyword, option);
+	public List<AdminReportedMemberDto> getReportedMembers(int page, String keyword, String option, Date minDate, Integer period, Integer num, String order) {
+		int size = num;
+		int offset=(page-1)*num;
+		List<AdminReportedMemberDto> list = reportedMemberDao.getAdminViewList(size, offset, keyword, option, minDate, period, order);
 		
 		return list;
 	}
 
 	@Override
-	public List<AdminReportedCommentDto> getReportedComments(int page, String keyword, String option) {
-		int size = 10;
-		int offset=(page-1)*size;
-		List<AdminReportedCommentDto> list = reportedCommentDao.getAdminViewList(size, offset, keyword, option);
+	public List<AdminReportedCommentDto> getReportedComments(int page, String keyword, String option, Date minDate, Integer period, Integer num, String order) {
+		int size = num;
+		int offset=(page-1)*num;
+		List<AdminReportedCommentDto> list = reportedCommentDao.getAdminViewList(size, offset, keyword, option, minDate, period, order);
 		
 		return list;
 	}
 
 	@Override
-	public List<AdminReportedMeetingDto> getReportedMeetings(int page, String keyword, String option) {
-		int size = 10;
+	public List<AdminReportedMeetingDto> getReportedMeetings(int page, String keyword, String option, Date minDate, Integer period, Integer num, String order) {
+		int size = num;
 		int offset=(page-1)*size;
-		List<AdminReportedMeetingDto> list = reportedMeetingDao.getAdminViewList(size, offset, keyword, option);
+		List<AdminReportedMeetingDto> list = reportedMeetingDao.getAdminViewList(size, offset , keyword, option, minDate, period, order);
 		
 		return list;
 	}
 
 	@Override
-	public int countReportedMembers(String keyword, String option) {
-		int count = reportedMemberDao.count(keyword, option);
-		return count;
+	public int countReportedMembers(String keyword, String option, Date minDate, Integer period) {
+		return reportedMemberDao.count(keyword, option, minDate, period);
 	}
 
 	@Override
-	public int countReportedComments(String keyword, String option) {
-		int count = reportedCommentDao.count(keyword, option);
-		return count;
+	public int countReportedComments(String keyword, String option, Date minDate, Integer period) {
+		return reportedCommentDao.count(keyword, option, minDate, period);
 	}
 
 	@Override
-	public int countReportedMeetings(String keyword, String option) {
-		int count = reportedMeetingDao.count(keyword, option);
-		return count;
+	public int countReportedMeetings(String keyword, String option,Date minDate, Integer period) {
+		return reportedMeetingDao.count(keyword, option, minDate, period);
 	}
 
+	@Override
+	public int cancelMemberReport(List<Integer> ids) {
+		/* 작업순서
+		 * 1. 신고id를 통해서 피신고자의 id 조회
+		 * 2. member table의 isSuspened 값을 false로 변경
+		 * 3. reportedMeeting table의 blockedAt, releasedAt을 null로 변경
+		 */
+
+		 List<ReportedMember> reportedMembers = reportedMemberDao.getByIds(ids);
+		 List<Integer> reportedMemberIds = reportedMembers.stream()
+								  .map(ReportedMember::getReportedId)
+								  .distinct()
+								  .collect(Collectors.toList());
+  
+		  Boolean isSuspended = false;
+		  memberDao.updateAllIsSuspended(reportedMemberIds, isSuspended);
+		  int processedAtResult = reportedMemberDao.updateAll(ids,null);
+  
+		  return processedAtResult;
+	}
+
+	@Transactional
+	@Override
+	public int cancelMeetingReport(List<Integer> ids) {
+
+		/* 작업순서 (dto를 만들어야할지? 아니면 이렇게 해야할지? dto를 만들기에는 부담스럽고, 아래처럼 하자니 복잡하네요)
+		 * 1. 신고id를 통해서 피신고자가 작성한 모임글의 id 조회
+		 * 2. 모임글id를 통해서 피신고자의 id 조회
+		 * 3. member table의 isSuspened 값을 false로 변경
+		 * 4. meeting table의 deletedAt을 null로 변경
+		 * 5. reportedMeeting table의 blockedAt, releasedAt을 null로 변경
+		 */
+
+		
+		List<ReportedMeeting> reportedMeetings = reportedMeetingDao.getByIds(ids);
+		List<Integer> meetingIds = reportedMeetings.stream()
+								.map(ReportedMeeting::getMeetingId)
+								.distinct()
+								.collect(Collectors.toList());
+		
+		List<Meeting> meetings = meetingDao.getByIds(meetingIds);
+		List<Integer> regMemberIds = meetings.stream()
+								.map(Meeting::getRegMemberId)
+								.distinct()
+								.collect(Collectors.toList());
+
+		Boolean isSuspended = false;
+		memberDao.updateAllIsSuspended(regMemberIds, isSuspended);
+		meetingDao.removeAllDeletedAt(meetingIds);
+		
+		
+		int result = reportedMeetingDao.updateAll(ids, null);
+
+		return result;
+	}
+
+	@Transactional
+	@Override
+	public int cancelCommentReport(List<Integer> ids) {
+
+		/* 작업순서 (dto를 만들어야할지? 아니면 이렇게 해야할지? dto를 만들기에는 부담스럽고, 아래처럼 하자니 복잡하네요)
+		 * 1. 신고id를 통해서 피신고자가 작성한 댓글의 id 조회
+		 * 2. 댓글 id를 통해서 작성자의 id 조회
+		 * 3. member table의 isSuspened 값을 false로 변경
+		 * 4. comment table의 deletedAt을 null로 변경
+		 * 5. reportedComment table의 blockedAt, releasedAt을 null로 변경
+		 */
+		List<ReportedComment> reportedComments = reportedCommentDao.getByIds(ids);
+		List<Integer> commentIds = reportedComments.stream()
+									.map(ReportedComment::getCommentId)
+									.distinct()
+									.collect(Collectors.toList());
+
+		List<Comment> comments = commentDao.getByIds(commentIds);
+		List<Integer> writerIds = comments.stream()
+									.map(Comment::getWriterId)
+									.distinct()
+									.collect(Collectors.toList());
+
+
+		Boolean isSuspended = false;
+		memberDao.updateAllIsSuspended(writerIds, isSuspended);
+		commentDao.removeAllDeletedAt(commentIds);
+		
+		int result = reportedCommentDao.updateAll(ids,null);
+		
+		return result;
+	}
+
+	@Transactional
+	@Override
+	public int suspendMemberReported(List<Integer> ids, Integer period) {
+		
+		/* 작업순서
+		 * 1. 신고id를 통해서 피신고자의 id 조회
+		 * 2. member table의 isSuspened 값을 true로 변경
+		 * 3. reportedMeeting table의 blockedAt, releasedAt을 각각 
+		 * 	  current_timestamp와 #{releasedAt} 으로 변경
+		 */
+		
+		Date releasedAt = getReleasedAtFromNow(period);
+
+		List<ReportedMember> reportedMembers = reportedMemberDao.getByIds(ids);
+		List<Integer> reportedMemberIds = reportedMembers.stream()
+								 .map(ReportedMember::getReportedId)
+								 .distinct()
+								 .collect(Collectors.toList());
+ 
+		 Boolean isSuspended = true;
+		 memberDao.updateAllIsSuspended(reportedMemberIds, isSuspended);
+		 int processedAtResult = reportedMemberDao.updateAll(ids,releasedAt);
+ 
+		 return processedAtResult;
+
+	}
+
+	@Transactional
+	@Override
+	public int suspendMeetingReported(List<Integer> ids, Integer period) {
+
+		//날짜 더하는 방법은 다음을 참조
+		//https://stackoverflow.com/questions/1005523/how-to-add-one-day-to-a-date
+		
+
+		/* 작업순서
+		 * 1. 신고id를 통해서 피신고자가 작성한 모임글의 id 조회
+		 * 2. 모임글id를 통해서 피신고자의 id 조회
+		 * 3. member table의 isSuspened 값을 true로 변경
+		 * 4. meeting table의 deletedAt을 current_timestamp 로 변경
+		 * 5. reportedMeeting table의 blockedAt, releasedAt을 각각 
+		 * 	  current_timestamp와 #{releasedAt} 으로 변경
+		 */
+		Date releasedAt = getReleasedAtFromNow(period);
+
+		List<ReportedMeeting> reportedMeetings = reportedMeetingDao.getByIds(ids);
+		List<Integer> meetingIds = reportedMeetings.stream()
+								.map(ReportedMeeting::getMeetingId)
+								.distinct()
+								.collect(Collectors.toList());
+		
+		List<Meeting> meetings = meetingDao.getByIds(meetingIds);
+		List<Integer> regMemberIds = meetings.stream()
+								.map(Meeting::getRegMemberId)
+								.distinct()
+								.collect(Collectors.toList());
+
+		Boolean isSuspended = true;
+		memberDao.updateAllIsSuspended(regMemberIds, isSuspended);
+		meetingDao.updateAllDeletedAt(meetingIds);
+		int processedAtResult = reportedMeetingDao.updateAll(ids,releasedAt);
+
+
+		return processedAtResult;
+	}
+
+	@Transactional
+	@Override
+	public int suspendCommentReported(List<Integer> ids, Integer period) {
+		
+		/* 작업순서
+		 * 1. 신고id를 통해서 피신고자가 작성한 댓글의 id 조회
+		 * 2. 댓글 id를 통해서 작성자의 id 조회
+		 * 3. member table의 isSuspened 값을 true로 변경
+		 * 4. comment table의 deletedAt을 current_timestamp로 변경
+		 * 5. reportedComment table의 blockedAt, releasedAt을 각각 
+		 * 	  current_timestamp와 #{releasedAt} 으로 변경
+		 */
+		Date releasedAt = getReleasedAtFromNow(period);
+
+		List<ReportedComment> reportedComments = reportedCommentDao.getByIds(ids);
+		List<Integer> commentIds = reportedComments.stream()
+									.map(ReportedComment::getCommentId)
+									.distinct()
+									.collect(Collectors.toList());
+
+		List<Comment> comments = commentDao.getByIds(commentIds);
+		List<Integer> writerIds = comments.stream()
+									.map(Comment::getWriterId)
+									.distinct()
+									.collect(Collectors.toList());
+
+		Boolean isSuspended = true;
+		memberDao.updateAllIsSuspended(writerIds, isSuspended);
+		commentDao.updateAllDeletedAt(commentIds);
+
+		int processedAtResult = reportedCommentDao.updateAll(ids,releasedAt);
+
+		return processedAtResult;
+	}
+
+	private static Date getReleasedAtFromNow(Integer period){
+		Date releasedAt = new Date();
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime(releasedAt);
+		calendar.add(Calendar.DATE, period);
+		releasedAt = calendar.getTime();
+		return releasedAt;
+	}
 }

--- a/src/main/resources/mapper/CommentDaoMapper.xml
+++ b/src/main/resources/mapper/CommentDaoMapper.xml
@@ -42,6 +42,16 @@
 			id = #{commentId}
 	</if>
   </select>
+  <select id="getByIds" resultType="Comment">
+	SELECT *
+	FROM comment
+	<where>
+		id IN
+		<foreach collection="ids" item="id" open="(" close=")" separator=",">
+			#{id}
+		</foreach>
+	</where>
+	</select>
   <insert id="insertComment" parameterType="com.zpop.web.entity.comment.Comment">
   	INSERT INTO comment 
 	  	(meetingId, writerId, content)
@@ -73,5 +83,112 @@
   	WHERE
   	id = #{commentId}
   </update>
+  <select id="getAdminList" resultType="AdminCommentDto">
+	SELECT 
+		c1.id,
+		c1.content,
+		c1.writerId,
+		c1.groupId,
+		mem.nickname,
+		m.id AS meetingId,
+		m.title AS meetingTitle,
+		c1.parentCommentId,
+		c2.writerId AS parentCommentWriterId,
+		c2.content AS parentCommentContent,
+		c1.createdAt,
+		c1.updatedAt,
+		c1.deletedAt
+	FROM comment AS c1
+	LEFT JOIN meeting AS m
+	ON c1.meetingId = m.id
+	LEFT JOIN member AS mem
+	ON c1.writerId = mem.id
+	LEFT OUTER JOIN comment AS c2
+	ON c1.parentCommentId = c2.id
+	<where>
+		<if test="keyword!=null and !keyword.equals('')">
+			<choose>
+				<when test="option.equals('title')">
+					m.title LIKE '%${keyword}%'
+				</when>
+				<when test="option.equals('nickname')">
+					mem.nickname LIKE '%${keyword}%'
+				</when>
+				<when test="option.equals('id')">
+					c1.id = #{keyword}
+				</when>
+			</choose>
+		</if>
+		<if test="period!=null and minDate!=null">
+			<![CDATA[
+			DATEDIFF(c1.createdAt, #{minDate}) <= 0
+			AND DATEDIFF(c1.createdAt, #{minDate}) >=  - #{period}
+			]]>
+		</if>
+	</where>
+	<choose>
+		<when test="order.equals('desc')">
+			ORDER BY c1.id DESC
+		</when>
+		<otherwise>
+			ORDER BY c1.id ASC
+		</otherwise>
+	</choose>
+	LIMIT #{offset}, #{size}
+  </select>
+  <select id="countBySearch" resultType= "java.lang.Integer">
+	SELECT COUNT(c1.id) 
+	FROM comment AS c1
+	LEFT JOIN meeting AS m
+	ON c1.meetingId = m.id
+	LEFT JOIN member AS mem
+	ON c1.writerId = mem.id
+	<where>
+		<if test="keyword!=null and !keyword.equals('')">
+			<choose>
+				<when test="option.equals('title')">
+					m.title LIKE '%${keyword}%'
+				</when>
+				<when test="option.equals('nickname')">
+					mem.nickname LIKE '%${keyword}%'
+				</when>
+				<when test="option.equals('id')">
+					c1.id = #{keyword}
+				</when>
+			</choose>
+		</if>
+		<if test="period!=null and minDate!=null">
+			AND
+			<![CDATA[
+			DATEDIFF(c1.createdAt, #{minDate}) <= 0
+			AND DATEDIFF(c1.createdAt, #{minDate}) >=  - #{period}
+			]]>
+		</if>
+	</where>
+</select>
+<update id="removeAllDeletedAt" parameterType="java.util.List">
+	UPDATE comment
+	<if test="ids != null and !ids.isEmpty()">
+		SET deletedAt=null
+		<where>
+			<foreach item="id" index="index" collection="ids"
+			open="id IN (" separator="," close=")">
+			#{id}
+			</foreach>
+		</where>
+	</if>
+</update>
+<update id="updateAllDeletedAt" parameterType="java.util.List">
+	UPDATE comment
+	<if test="ids != null and !ids.isEmpty()">
+		SET deletedAt=CURRENT_TIMESTAMP
+		<where>
+			id IN 
+			<foreach item="id" index="index" collection="ids"
+			open="(" separator="," close=")">
+			#{id}
+			</foreach>
+		</where>
+	</if>
+</update>
 </mapper>
-

--- a/src/main/resources/mapper/MeetingDaoMapper.xml
+++ b/src/main/resources/mapper/MeetingDaoMapper.xml
@@ -14,13 +14,24 @@
         UPDATE meeting
         SET content=#{content}
         WHERE id = #{id}
-    </update>
+	</update>
 
     <select id="get" resultType="com.zpop.web.entity.meeting.Meeting">
         SELECT *
         FROM meeting
         WHERE id=#{id}
     </select>
+
+	<select id="getByIds" resultType="Meeting">
+		SELECT *
+		FROM meeting
+		<where>
+			id IN
+			<foreach collection="ids" item="id" open="(" close=")" separator=",">
+				#{id}
+			</foreach>
+		</where>
+	</select>
 
     <select id="getThumbnailViewList" parameterType="com.zpop.web.dto.MeetingThumbnailPagination"
         resultType="com.zpop.web.entity.meeting.MeetingThumbnailView">
@@ -63,6 +74,13 @@
         deletedAt=NOW()
         WHERE id = #{id}
     </update>
+
+	<update id="removeDeletedAt" parameterType="Meeting">
+		UPDATE meeting
+        SET
+        deletedAt=null
+        WHERE id = #{id}
+	</update>
 
     <update id="updateClosedAt" parameterType="com.zpop.web.entity.meeting.Meeting">
         UPDATE meeting
@@ -131,31 +149,71 @@
 		JOIN member
 		ON meeting.regMemberId = member.id
 		LEFT OUTER JOIN(
-		SELECT
-		meetingId,
-		COUNT(IF(bannedAt IS NULL AND canceledAt IS NULL,1, NULL))
-		as num
-		FROM participation
-		GROUP BY meetingId
-		) AS pNum
+			SELECT
+			meetingId,
+			COUNT(IF(bannedAt IS NULL AND canceledAt IS NULL,1, NULL))
+			as num
+			FROM participation
+			GROUP BY meetingId
+			) AS pNum
 		ON
 		pNum.meetingId=meeting.id
-		ORDER BY meeting.id DESC
-		LIMIT
-		#{offset},#{size};
 		<where>
-			<if test="keyword!=null">
-				title LIKE '%${keyword}%'
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('title')">
+						meeting.title LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('nickname')">
+						member.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						meeting.id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				AND
+				<![CDATA[
+				DATEDIFF(meeting.createdAt, #{minDate}) <=  0
+				AND DATEDIFF(meeting.createdAt, #{minDate}) >=  - #{period}
+				]]>
 			</if>
 		</where>
+		<choose>
+			<when test="order.equals('desc')">
+				ORDER BY meeting.id DESC
+			</when>
+			<otherwise>
+				ORDER BY meeting.id ASC
+			</otherwise>
+		</choose>
+		LIMIT
+		#{offset},#{size}
 	</select>
-	<!-- 검색어 옵션 뭐가될지 잘 몰라서 우선 모임글 제목만 함 -->
 	<select id="count" resultType="java.lang.Integer">
 		SELECT COUNT(id)
 		FROM meeting
 		<where>
-			<if test="keyword!=null">
-				title LIKE '%${keyword}%'
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('title')">
+						meeting.title LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('nickname')">
+						member.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						meeting.id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				AND
+				<![CDATA[
+				DATEDIFF(meeting.createdAt, #{minDate}) <=  0
+				AND DATEDIFF(meeting.createdAt, #{minDate}) >=  - #{period}
+				]]>
 			</if>
 		</where>
 	</select>
@@ -224,4 +282,30 @@
 		SELECT commentCount FROM meeting
 		WHERE id = #{id}
 	</select>
+
+	<update id="removeAllDeletedAt" parameterType="java.util.List">
+		UPDATE meeting
+		<if test="ids != null and !ids.isEmpty()">
+			SET deletedAt=null
+			<where>
+				<foreach item="id" index="index" collection="ids"
+				open="id IN (" separator="," close=")">
+				#{id}
+				</foreach>
+			</where>
+		</if>
+	</update>
+	<update id="updateAllDeletedAt" parameterType="java.util.List">
+		UPDATE meeting
+		<if test="ids != null and !ids.isEmpty()">
+			SET deletedAt=CURRENT_TIMESTAMP
+			<where>
+				id IN 
+				<foreach item="id" index="index" collection="ids"
+				open="(" separator="," close=")">
+				#{id}
+				</foreach>
+			</where>
+		</if>
+	</update>
 </mapper>

--- a/src/main/resources/mapper/MemberDaoMapper.xml
+++ b/src/main/resources/mapper/MemberDaoMapper.xml
@@ -46,11 +46,25 @@
     <select id="countBySearch" resultType= "java.lang.Integer">
       	SELECT COUNT(id) 
       	FROM member
-      	<where>
-      		<if test="keyword!=null">
-      			nickname LIKE '%${keyword}%'
-      		</if>
-      	</where>
+		<where>
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('nickname')">
+						nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				AND
+				<![CDATA[
+				DATEDIFF(createdAt, #{minDate}) <= 0
+				AND DATEDIFF(createdAt, #{minDate}) >=  - #{period}
+				]]>
+			</if>
+		</where>
     </select>
     <select id="getListBySearch" resultType="Member">
     	SELECT 
@@ -63,14 +77,33 @@
     		resignedAt
    		FROM
    			member
-   		ORDER BY id DESC
-   		LIMIT #{offset},#{size};
-   		<!-- 검색어 옵션 뭐가될지 잘 몰라서 우선 닉네임만 함 -->
-  		<where>
-      		<if test="keyword!=null">
-      			nickname LIKE '%${keyword}%'
-      		</if>
-      	</where>
+   		<where>
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('nickname')">
+						nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				<![CDATA[
+				DATEDIFF(createdAt, #{minDate}) <= 0
+				AND DATEDIFF(createdAt, #{minDate}) >=  - #{period}
+				]]>
+			</if>
+		</where>
+		<choose>
+			<when test="order.equals('desc')">
+				ORDER BY id DESC
+			</when>
+			<otherwise>
+				ORDER BY id ASC
+			</otherwise>
+		</choose>
+		LIMIT #{offset},#{size};
     </select>
 	<update id="updateFameAll" parameterType="java.util.List">
 		<foreach item="item" index="index" collection="list"
@@ -80,4 +113,17 @@
 			WHERE id=#{item.evaluateeId}
 		</foreach>
 	</update>
+
+	<update id="updateAllIsSuspended" parameterType="java.util.List">
+		UPDATE member
+		<if test="ids != null and !ids.isEmpty()">
+			SET isSuspended=#{isSuspended}
+		</if>
+		<where>
+			ID IN 
+			<foreach item="id" collection="ids" open="(" close=")"
+			separator=",">#{id}</foreach>
+		</where>
+	</update>
+
 </mapper>

--- a/src/main/resources/mapper/ReportedCommentDaoMapper.xml
+++ b/src/main/resources/mapper/ReportedCommentDaoMapper.xml
@@ -18,6 +18,8 @@
 			m2.nickname AS writerNickname,
 			m2.id AS writerId,
 			crt.type as reportType,
+			rc.reason,
+			rc.createdAt,
 			rc.processedAt
 		FROM reportedComment as rc
 		JOIN member as m1
@@ -28,16 +30,107 @@
 		ON comment.writerId = m2.id
 		JOIN commentReportType AS crt
 		ON rc.typeId = crt.id
+		<trim prefix="WHERE" prefixOverrides="AND | OR">
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('original')">
+						rc.original LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('reporterNickname')">
+						m1.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('writerNickname')">
+						m2.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						rc.id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				<![CDATA[
+				AND DATEDIFF(rc.createdAt, #{minDate}) >=  - #{period}
+				]]>
+			</if>
+		</trim>
+		<choose>
+			<when test="order.equals('desc')">
+				ORDER BY rc.id DESC
+			</when>
+			<otherwise>
+				ORDER BY rc.id ASC
+			</otherwise>
+		</choose>
 		LIMIT #{offset},#{size}
 	</select>
 	
 	<select id="count" resultType="Integer">
-		SELECT count(id)
-		FROM reportedComment;
+		SELECT COUNT(rc.id)
+		FROM reportedComment as rc
+		JOIN member as m1
+		ON rc.reporterId = m1.id
+		JOIN comment
+		ON rc.commentId = comment.id
+		JOIN member as m2
+		ON comment.writerId = m2.id
+		JOIN commentReportType AS crt
+		ON rc.typeId = crt.id
+		<trim prefix="WHERE" prefixOverrides="AND | OR">
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('original')">
+						rc.original LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('reporterNickname')">
+						m1.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('writerNickname')">
+						m2.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						rc.id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				<![CDATA[
+				AND DATEDIFF(rc.createdAt, #{minDate}) >=  - #{period}
+				]]>
+			</if>
+		</trim>
 	</select>
-	
 	<select id="select" resultType="Integer">
 		SELECT id FROM reportedComment WHERE commentId = #{commentId} AND reporterId = #{reporterId};
 	</select>
-
+	<update id="updateAll" parameterType="java.util.List">
+		UPDATE reportedComment
+		<if test="ids!=null and !ids.isEmpty()">
+			SET processedAt=CURRENT_TIMESTAMP
+			<choose>
+				<when test="releasedAt != null">
+					,blockedAt=CURRENT_TIMESTAMP
+					,releasedAt=#{releasedAt}
+				</when>
+				<otherwise>
+					,blockedAt=null
+					,releasedAt=null
+				</otherwise>
+			</choose>
+			<where>
+				ID IN 
+				<foreach item="id" collection="ids" open="(" close=")"
+				separator=",">#{id}</foreach>
+			</where>
+		</if>
+	</update>
+	<select id="getByIds" resultType="ReportedComment">
+		SELECT *
+		FROM reportedComment
+		<where>
+			id IN
+			<foreach collection="ids" item="id" open="(" close=")" separator=",">
+				#{id}
+			</foreach>
+		</where>
+	</select>
 </mapper>

--- a/src/main/resources/mapper/ReportedMeetingDaoMapper.xml
+++ b/src/main/resources/mapper/ReportedMeetingDaoMapper.xml
@@ -18,6 +18,8 @@
 			member2.nickname AS writerNickname,
 			member2.id AS writerId,
 			mrt.type AS reportType,
+			rm.reason,
+			rm.createdAt,
 			rm.processedAt
 		FROM reportedMeeting as rm
 		JOIN member as member1
@@ -28,11 +30,75 @@
 		on meeting.regMemberId = member2.id
 		JOIN meetingReportType as mrt
 		on rm.typeId = mrt.id
+		<where>
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('title')">
+						meeting.title LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('reporterNickname')">
+						member1.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('writerNickname')">
+						member2.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						rm.id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				AND
+				<![CDATA[
+				DATEDIFF(rm.createdAt, #{minDate}) <=  0
+				AND DATEDIFF(rm.createdAt, #{minDate}) >=  - #{period}
+				]]>
+			</if>
+		</where>
+		<choose>
+			<when test="order.equals('desc')">
+				ORDER BY rm.id DESC
+			</when>
+			<otherwise>
+				ORDER BY rm.id ASC
+			</otherwise>
+		</choose>
 		LIMIT #{offset},#{size}
 	</select>
 	<select id="count" resultType="java.lang.Integer">
-		SELECT count(id)
-		FROM reportedMeeting;
+		SELECT COUNT(rm.id)
+		FROM reportedMeeting as rm
+		JOIN member as member1
+		ON rm.reporterId = member1.id
+		JOIN meeting
+		ON rm.meetingId = meeting.id
+		JOIN member as member2
+		on meeting.regMemberId = member2.id
+		<where>
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('title')">
+						meeting.title LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('reporterNickname')">
+						member1.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('writerNickname')">
+						member2.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						rm.id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				AND
+				<![CDATA[
+				DATEDIFF(rm.createdAt, #{minDate}) <=  0
+				AND DATEDIFF(rm.createdAt, #{minDate}) >=  - #{period}
+				]]>
+			</if>
+		</where>
 	</select>
 	
 	<select id="getReportedMeetingId" resultType="Integer">
@@ -40,5 +106,35 @@
 		WHERE meetingId = #{meetingId}
 		AND reporterId = #{reporterId}
 	</select>
-
+	<update id="updateAll" parameterType="java.util.List">
+		UPDATE reportedMeeting
+		<if test="ids!=null and !ids.isEmpty()">
+			SET processedAt=CURRENT_TIMESTAMP
+			<choose>
+				<when test="releasedAt != null">
+					,blockedAt=CURRENT_TIMESTAMP
+					,releasedAt=#{releasedAt}
+				</when>
+				<otherwise>
+					,blockedAt=null
+					,releasedAt=null
+				</otherwise>
+			</choose>
+			<where>
+				ID IN 
+				<foreach item="id" collection="ids" open="(" close=")"
+				separator=",">#{id}</foreach>
+			</where>
+		</if>
+	</update>
+	<select id="getByIds" resultType="ReportedMeeting">
+		SELECT *
+		FROM reportedMeeting
+		<where>
+			id IN
+			<foreach collection="ids" item="id" open="(" close=")" separator=",">
+				#{id}
+			</foreach>
+		</where>
+	</select>
 </mapper>

--- a/src/main/resources/mapper/ReportedMemberDaoMapper.xml
+++ b/src/main/resources/mapper/ReportedMemberDaoMapper.xml
@@ -17,19 +17,109 @@
 			m2.nickname as reportedNickname,
 			m2.id as reportedId,
 			mrt.type as reportType,
+			rm.reason,
+			rm.createdAt,
 			rm.processedAt
 		FROM reportedMember as rm
 		JOIN member as m1
-		ON rm.repoterId = m1.id
+		ON rm.reporterId = m1.id
 		JOIN member as m2
 		ON rm.reportedId = m2.id
 		JOIN memberReportType as mrt
 		ON rm.typeId = mrt.id
+		<where>
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('reporterNickname')">
+						m1.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('reportedNickname')">
+						m2.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						rm.id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				AND
+				<![CDATA[
+				DATEDIFF(rm.createdAt, #{minDate}) <=  0
+				AND DATEDIFF(rm.createdAt, #{minDate}) >=  - #{period}
+				]]>
+			</if>
+		</where>
+		<choose>
+			<when test="order.equals('desc')">
+				ORDER BY rm.id DESC
+			</when>
+			<otherwise>
+				ORDER BY rm.id ASC
+			</otherwise>
+		</choose>
 		LIMIT #{offset},#{size};
 	</select>
 	<select id="count" resultType="java.lang.Integer">
-		SELECT count(id)
-		FROM reportedMember;
+		SELECT COUNT(rm.id)
+		FROM reportedMember as rm
+		JOIN member as m1
+		ON rm.reporterId = m1.id
+		JOIN member as m2
+		ON rm.reportedId = m2.id
+		JOIN memberReportType as mrt
+		ON rm.typeId = mrt.id
+		<where>
+			<if test="keyword!=null and !keyword.equals('')">
+				<choose>
+					<when test="option.equals('reporterNickname')">
+						m1.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('reportedNickname')">
+						m2.nickname LIKE '%${keyword}%'
+					</when>
+					<when test="option.equals('id')">
+						rm.id = #{keyword}
+					</when>
+				</choose>
+			</if>
+			<if test="period!=null and minDate!=null">
+				AND
+				<![CDATA[
+				DATEDIFF(rm.createdAt, #{minDate}) <=  0
+				AND DATEDIFF(rm.createdAt, #{minDate}) >=  - #{period}
+				]]>
+			</if>
+		</where>
 	</select>
-
+	<update id="updateAll" parameterType="java.util.List">
+		UPDATE reportedMember
+		<if test="ids!=null and !ids.isEmpty()">
+			SET processedAt=CURRENT_TIMESTAMP
+			<choose>
+				<when test="releasedAt != null">
+					,blockedAt=CURRENT_TIMESTAMP
+					,releasedAt=#{releasedAt}
+				</when>
+				<otherwise>
+					,blockedAt=null
+					,releasedAt=null
+				</otherwise>
+			</choose>
+			<where>
+				ID IN 
+				<foreach item="id" collection="ids" open="(" close=")"
+				separator=",">#{id}</foreach>
+			</where>
+		</if>
+	</update>
+	<select id="getByIds" resultType="ReportedMember">
+		SELECT *
+		FROM reportedMember
+		<where>
+			id IN
+			<foreach collection="ids" item="id" open="(" close=")" separator=",">
+				#{id}
+			</foreach>
+		</where>
+	</select>
 </mapper>

--- a/src/main/vue/src/api/admin/index.js
+++ b/src/main/vue/src/api/admin/index.js
@@ -1,0 +1,9 @@
+import meeting from "./meeting.js";
+// import member from "./member.js";
+// import notification from "./notification.js"
+
+export default {
+  meeting,
+//   member,
+//   notification,
+};

--- a/src/main/vue/src/api/admin/meeting.js
+++ b/src/main/vue/src/api/admin/meeting.js
@@ -1,0 +1,28 @@
+async function getDetailsForUpdate(id){
+    const url = `/api/admin/meeting/${id}`;
+    return await fetch(url);
+}
+
+// getDeleted가 true이면 삭제, false이면 삭제 취소
+async function deleteMeeting(id, getDeleted){
+    const url = `/api/admin/meeting/${id}?getDeleted=${getDeleted}`;
+    const option = {
+        method:'DELETE'
+    }
+    return await fetch(url, option);
+}
+
+// getDeleted가 true이면 삭제, false이면 삭제 취소
+async function deleteAllMeeting(ids, getDeleted){
+    const url = `/api/admin/meeting?ids=${ids}&getDeleted=${getDeleted}`;
+    const option = {
+        method:'DELETE'
+    }
+    return await fetch(url, option);
+}
+
+export default{
+    getDetailsForUpdate,
+    deleteMeeting,
+    deleteAllMeeting,
+}

--- a/src/main/vue/src/assets/css/admin/component/admin-list.css
+++ b/src/main/vue/src/assets/css/admin/component/admin-list.css
@@ -1,0 +1,101 @@
+.admin-table{
+    position:relative;
+    
+}
+
+.table-list{
+    width:100%;
+    border-spacing: 0;
+    border-collapse: collapse;
+}
+
+.table-list__header{
+    height:54px;
+    background-color: #f8fafc;
+    border: 1px solid var(--light-grey1);
+}
+
+.table-list__header li:first-child > *{
+    display: inline-flex;
+    padding-left:5px;
+}
+
+.table-list__header button{
+    margin-left: 10px;
+    cursor: pointer;
+}
+
+.table-list__content, .table-list__header{
+    padding:10px 30px;
+}
+
+.table-list__header ul {
+    display: flex;
+    height:100%;
+}
+
+.table-list__content ul li, .table-list__header ul li{
+    flex: 0 1 100px;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.table-list__content{
+    transition:box-shadow 0.05s 0.05s;
+    height: fit-content;
+    border: 1px solid var(--light-grey1);
+}
+
+.table-list__content:hover{
+    box-shadow:1px 1px 13px var(--light-grey1);
+}
+
+
+.table-list__content ul li:first-child,
+.table-list__header ul li:first-child{
+    justify-content: flex-start;
+}
+
+.table-list .list-content__title > span:first-child {
+    overflow:hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width:500px;
+}
+
+.table-list .list-content__nickname{
+    flex-direction: row;
+    column-gap:10px;
+}
+
+.table-list__content--wrapper{
+    position:relative;
+    min-height: 650px;
+}
+
+.list-content{
+    display: flex;
+}
+
+.list-content__id > span{
+    margin-top:1px;
+    font-size: 16px;
+    margin-left: 9px;
+}
+
+.admin-tb-4{
+    flex:1 1 330px !important;
+}
+
+.admin-tb-3{
+    flex:1 1 220px !important;
+}
+
+.admin-tb-2{
+    flex:1 1 110px !important;
+} 
+
+.admin-tb-1{
+    flex:0 1 100px !important;
+} 

--- a/src/main/vue/src/assets/css/admin/component/button.css
+++ b/src/main/vue/src/assets/css/admin/component/button.css
@@ -1,0 +1,26 @@
+input[type="checkbox"].checkbox {
+  appearance: none;
+  background-color: var(--white);
+  width: 1rem;
+  height: 1rem;
+  border-radius: 25%;
+  cursor: pointer;
+  border: 1px solid var(--grey2);
+  margin: 0;
+}
+
+input[type="checkbox"].checkbox:checked {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  content: "";
+  background-image: url(/images/icon/check.svg);
+  background-position: 50%;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+input[type="checkbox"].checkbox:focus {
+  box-shadow: 0 0px 3px var(--tiffany-blue);
+  border: 1px solid var(--tiffany-blue);
+}

--- a/src/main/vue/src/assets/css/admin/component/select.css
+++ b/src/main/vue/src/assets/css/admin/component/select.css
@@ -1,0 +1,163 @@
+.select-box{
+    position:relative;
+    display: flex;
+    align-items: center;
+    font-size: 16px;
+    color:var(--dark-grey2);
+    font-weight: var(--regular);
+  }
+  
+  .select-box *{
+    font-size: 18px;
+  }
+  
+  .input-text{
+    width:100%;
+    padding:8px 18px;
+    cursor: pointer;
+    border-bottom: 2px solid var(--admin-grey);
+    max-width:500px;
+  }
+
+  .input-text__content{
+    border:none;
+    font-size:18px;
+  }
+  
+  .select-box > span{
+    margin-top:8px;
+    width:100%;
+    padding:10px 18px;
+    cursor: pointer;
+    border:none;
+
+    border-bottom: 2px solid var(--admin-grey);
+  }
+  
+  @media (min-width:576px) {
+    .select-box > span {
+      padding:10px 20px;
+    }
+  }
+  
+  
+  .select-box--round > span{
+    border-radius: 50px;
+  }
+  
+  .select-box::before{
+    position: absolute;
+    right:0px;
+    width:16px;
+    height:16px;
+    display: inline-block;
+    content: "";
+    background: url("/images/icon/arrow-down.svg");
+    background-size: contain;
+    background-repeat: no-repeat;
+    transition: transform 0.2s;
+  }
+  
+  .select-box--expanded::before{
+    transform: rotate(180deg);
+  }
+  
+  
+  .select-box__options{
+    border-radius: 5px;
+    position: absolute;
+    top:100%;
+    box-shadow: 0 5px 5px rgba(0,0,0,0.15);
+    width: 100%;
+    max-height: 0;
+    overflow: hidden;
+    transform-origin: top;
+    background-color: var(--white);
+    z-index: 1;
+  }
+  
+  .select-box__options--right{
+    right:-50%;
+  }
+  
+  .select-box__options--left{
+    left:0;
+  }
+  
+  
+  .select-box__options--header{
+    width:216px;
+  }
+  
+  
+  .select-box__options > li{
+    padding:14px 18px;
+    cursor: pointer;
+    transition: 0.3s background-color, 0.3s color;
+  }
+  
+  @media (min-width:576px) {
+    .select-box__options > li{
+      padding:14px 20px;
+    }
+  }
+  
+  
+  
+  .select-box__options--header > li{
+    padding:10px 15px;
+  }
+  
+  
+  .select-box__options > li:hover{
+    background-color: var(--true-blue);
+    color:var(--white);
+  }
+  
+  .select-box__options > li:not(:last-child){
+    border-bottom: 0.3px solid var(--light-grey1);
+  }
+  
+  .select-box--expanded .select-box__options{
+    max-height: fit-content;
+  }
+  
+  
+  
+  
+  .modal-select{
+    height: fit-content;
+  width: 200px;
+  border-radius: 5px;
+  box-shadow: 0px 5px 15px 0px #00000033;
+  cursor: none;
+  
+  }
+  .modal-select__contents{
+  display: flex;
+  height: 100%;
+  width: 100%;
+  left: 0px;
+  top: 0px;
+  border-radius: 0px;
+  padding: 10px 0px 10px 15px;
+  border-bottom: var(--light-grey1) 0.3px solid;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  
+  }
+  
+  
+  .modal-select .icon{
+    display: flex;
+    margin-right: 15px;
+  }
+  
+  .modal-select :nth-child(3){ 
+    color: var(--red-theme);
+  }
+
+  .input__label, .input-text__label{
+    font-weight: var(--bold);
+  }

--- a/src/main/vue/src/assets/css/admin/component/status.css
+++ b/src/main/vue/src/assets/css/admin/component/status.css
@@ -1,0 +1,51 @@
+:root{
+    --positive-status: #B6E2C4;
+    --positive-status-text: #25A664;
+    --neutral-status: #FFE199;
+    --neutral-status-text: #B28826;
+    --negative-status-text: var(--dark-grey1);
+    --negative-status: #fcbdbd; 
+    --negative-status-text: #C9484E; 
+    --incomplete-status: #CFD0D3;
+    --incomplete-status-text: #53555A;
+    --height: 2rem;
+    --font-size: calc(var(--height)/2);
+    --width: calc(2 * var(--height));
+}
+
+.status{
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    min-width:var(--width);
+    width:fit-content;
+    padding: calc(var(--font-size)/2) var(--font-size);
+    border-radius: calc(var(--height)/5);
+    font-size: var(--font-size);
+    font-weight: bold;
+    position: relative;
+}
+
+.status--round{
+    border-radius: var(--height);
+}
+
+.status--positive{
+    background-color: var(--positive-status);
+    color: var(--positive-status-text);
+}
+
+.status--neutral{
+    background-color: var(--neutral-status);
+    color: var(--neutral-status-text);
+}
+
+.status--negative{
+    background-color: var(--negative-status);
+    color: var(--negative-status-text);
+}
+
+.status--incomplete{
+    background-color: var(--incomplete-status);
+    color: var(--incomplete-status-text);
+}

--- a/src/main/vue/src/assets/css/admin/component/table-bar.css
+++ b/src/main/vue/src/assets/css/admin/component/table-bar.css
@@ -1,0 +1,90 @@
+.table-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgb(255, 255, 255);
+  border: 1px solid #ebebeb;
+  border-radius: 10px 10px 0 0;
+  min-height: 3rem;
+  padding: 0 30px;
+}
+
+.table-bar__left-container,
+.table-bar__right-container {
+  display: flex;
+  align-items: center;
+}
+
+.table-bar__page {
+  font-weight: 300;
+}
+
+/* 아이콘 */
+.table-bar__left-container > .table-bar__icon,
+.table-bar input.checkbox {
+  margin-right: 1rem;
+}
+
+.table-bar__right-container > .table-bar__icon {
+  margin-left: 1rem;
+}
+
+.table-bar__icon {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px;
+  cursor: pointer;
+  transition: 0.5s;
+}
+
+.table-bar__icon::before {
+  content: "";
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.table-bar__icon:hover {
+  background-color: #ebebeb;
+  border-radius: 50%;
+}
+
+.table-bar__icon-check::before {
+  background-image: url(/images/icon/check.svg);
+}
+
+.table-bar__icon-x::before {
+  background-image: url(/images/icon/x.svg);
+}
+
+.table-bar__icon-plus::before {
+  background-image: url(/images/icon/plus.svg);
+}
+
+.table-bar__icon-arrow-left::before {
+  background-image: url(/images/icon/arrow-left.svg);
+}
+
+.table-bar__icon-arrow-right::before {
+  background-image: url(/images/icon/arrow-right.svg);
+}
+
+.table-bar__icon--user-ban::before{
+  background-image: url(/images/icon/user-ban.svg);
+}
+
+.table-bar__icon--user-check::before{
+  background-image: url(/images/icon/user-check.svg);
+}
+
+.table-bar__icon--user-suspend::before{
+  background-image: url(/images/icon/user-suspend.svg);
+}
+
+@media (min-width: 576px) {
+  .table-bar {
+    min-height: 3.5rem;
+  }
+}

--- a/src/main/vue/src/assets/css/button.css
+++ b/src/main/vue/src/assets/css/button.css
@@ -23,6 +23,12 @@
 }
 
 
+.btn-action--admin {
+  background-color: var(--admin-loyal-blue);
+}
+
+
+
 .btn-cancel {
   background-color: var(--grey2);
 }

--- a/src/main/vue/src/assets/css/deco.css
+++ b/src/main/vue/src/assets/css/deco.css
@@ -156,3 +156,55 @@
     display: none;
   }
 }
+
+.loader{
+  position:absolute;
+  width:100%;
+  height:100%;
+  top:0;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+
+.loader::before {
+  display: inline-block;
+  content: '';
+  font-size: 10px;
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  position: absolute;
+  animation: mulShdSpin 1.1s infinite ease;
+  top: 40%;
+  left:50%;
+  z-index: 100;
+}
+
+@keyframes mulShdSpin {
+  0%,
+  100% {
+    box-shadow: 0em -2.6em 0em 0em #ffffff, 1.8em -1.8em 0 0em rgba(100,100,100, 0.2), 2.5em 0em 0 0em rgba(100,100,100, 0.2), 1.75em 1.75em 0 0em rgba(100,100,100, 0.2), 0em 2.5em 0 0em rgba(100,100,100, 0.2), -1.8em 1.8em 0 0em rgba(100,100,100, 0.2), -2.6em 0em 0 0em rgba(100,100,100, 0.5), -1.8em -1.8em 0 0em rgba(100,100,100, 0.7);
+  }
+  12.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(100,100,100, 0.7), 1.8em -1.8em 0 0em #ffffff, 2.5em 0em 0 0em rgba(100,100,100, 0.2), 1.75em 1.75em 0 0em rgba(100,100,100, 0.2), 0em 2.5em 0 0em rgba(100,100,100, 0.2), -1.8em 1.8em 0 0em rgba(100,100,100, 0.2), -2.6em 0em 0 0em rgba(100,100,100, 0.2), -1.8em -1.8em 0 0em rgba(100,100,100, 0.5);
+  }
+  25% {
+    box-shadow: 0em -2.6em 0em 0em rgba(100,100,100, 0.5), 1.8em -1.8em 0 0em rgba(100,100,100, 0.7), 2.5em 0em 0 0em #ffffff, 1.75em 1.75em 0 0em rgba(100,100,100, 0.2), 0em 2.5em 0 0em rgba(100,100,100, 0.2), -1.8em 1.8em 0 0em rgba(100,100,100, 0.2), -2.6em 0em 0 0em rgba(100,100,100, 0.2), -1.8em -1.8em 0 0em rgba(100,100,100, 0.2);
+  }
+  37.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(100,100,100, 0.2), 1.8em -1.8em 0 0em rgba(100,100,100, 0.5), 2.5em 0em 0 0em rgba(100,100,100, 0.7), 1.75em 1.75em 0 0em #ffffff, 0em 2.5em 0 0em rgba(100,100,100, 0.2), -1.8em 1.8em 0 0em rgba(100,100,100, 0.2), -2.6em 0em 0 0em rgba(100,100,100, 0.2), -1.8em -1.8em 0 0em rgba(100,100,100, 0.2);
+  }
+  50% {
+    box-shadow: 0em -2.6em 0em 0em rgba(100,100,100, 0.2), 1.8em -1.8em 0 0em rgba(100,100,100, 0.2), 2.5em 0em 0 0em rgba(100,100,100, 0.5), 1.75em 1.75em 0 0em rgba(100,100,100, 0.7), 0em 2.5em 0 0em #ffffff, -1.8em 1.8em 0 0em rgba(100,100,100, 0.2), -2.6em 0em 0 0em rgba(100,100,100, 0.2), -1.8em -1.8em 0 0em rgba(100,100,100, 0.2);
+  }
+  62.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(100,100,100, 0.2), 1.8em -1.8em 0 0em rgba(100,100,100, 0.2), 2.5em 0em 0 0em rgba(100,100,100, 0.2), 1.75em 1.75em 0 0em rgba(100,100,100, 0.5), 0em 2.5em 0 0em rgba(100,100,100, 0.7), -1.8em 1.8em 0 0em #ffffff, -2.6em 0em 0 0em rgba(100,100,100, 0.2), -1.8em -1.8em 0 0em rgba(100,100,100, 0.2);
+  }
+  75% {
+    box-shadow: 0em -2.6em 0em 0em rgba(100,100,100, 0.2), 1.8em -1.8em 0 0em rgba(100,100,100, 0.2), 2.5em 0em 0 0em rgba(100,100,100, 0.2), 1.75em 1.75em 0 0em rgba(100,100,100, 0.2), 0em 2.5em 0 0em rgba(100,100,100, 0.5), -1.8em 1.8em 0 0em rgba(100,100,100, 0.7), -2.6em 0em 0 0em #ffffff, -1.8em -1.8em 0 0em rgba(100,100,100, 0.2);
+  }
+  87.5% {
+    box-shadow: 0em -2.6em 0em 0em rgba(100,100,100, 0.2), 1.8em -1.8em 0 0em rgba(100,100,100, 0.2), 2.5em 0em 0 0em rgba(100,100,100, 0.2), 1.75em 1.75em 0 0em rgba(100,100,100, 0.2), 0em 2.5em 0 0em rgba(100,100,100, 0.2), -1.8em 1.8em 0 0em rgba(100,100,100, 0.5), -2.6em 0em 0 0em rgba(100,100,100, 0.7), -1.8em -1.8em 0 0em #ffffff;
+  }
+}

--- a/src/main/vue/src/assets/css/icon.css
+++ b/src/main/vue/src/assets/css/icon.css
@@ -189,3 +189,7 @@
     height: 12px;
     background-image: url(/images/icon/location.svg);
   }
+
+  .icon-x-white{
+    background-image: url(/images/icon/x-white.svg);
+  }

--- a/src/main/vue/src/components/admin/Category.vue
+++ b/src/main/vue/src/components/admin/Category.vue
@@ -1,0 +1,52 @@
+<template>
+    <nav class="admin-nav">
+        <ul class="admin-nav__lists">
+            <li v-for="(category,index) in categories" :key="index"
+                class="admin-nav__list" :class="{'admin-nav__list--selected':(categoryStatus == index)}">
+                <router-link :to="category.link">{{ category.name }}</router-link>
+            </li>
+        </ul>
+    </nav>
+</template>
+
+<script setup>
+
+const props = defineProps(['categories','categoryStatus']);
+
+</script>
+
+<style scoped>
+.admin-nav-wrapper{
+    /* width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+    padding-bottom: 1rem; */
+    
+}
+
+.admin-nav__lists{
+    font-size: 20px;
+    border-bottom: 3px solid var(--admin-light-grey);
+    padding:1rem 0rem;
+    color: var(--admin-loyal-blue);
+    /* margin: 0 10rem; */
+}
+
+.admin-nav{
+    width: 90%;
+}
+
+
+
+.admin-nav__list{
+    cursor: pointer;
+    display: inline;
+    padding: 0 1rem
+}
+
+.admin-nav__list--selected{
+    border-bottom: 2px solid var(--admin-loyal-blue);
+    padding-bottom: 1rem;
+    font-weight: bold;
+}
+</style>

--- a/src/main/vue/src/components/admin/Header.vue
+++ b/src/main/vue/src/components/admin/Header.vue
@@ -1,0 +1,146 @@
+<template>
+  <aside @click="clickHandler" class="left-side-bar" :class="{'expended' : isExpanded}">
+        <router-link to="/"><img src="/images/logo/logo-with-text.svg" alt="로고"></router-link>
+        <nav>
+            <ul>
+                <li :class="{'selected':(props.status==0)}">
+                    <router-link class="add-deco-img-left deco-img-home" 
+                    :class="{'deco-img-home-white':(props.status==0)}"
+                    to="/admin/home">대시보드</router-link>
+                </li>
+                <li :class="{'selected':(props.status==1)}">
+                    <router-link class="add-deco-img-left deco-img-notification" 
+                    :class="{'deco-img-notification-white':(props.status==1)}"
+                    to="/admin/banner/list">공지 관리</router-link>
+                </li>
+                <li :class="{'selected':(props.status==2)}">
+                    <router-link class="add-deco-img-left deco-img-meeting" 
+                    :class="{'deco-img-meeting-white':(props.status==2)}"
+                    to="/admin/meeting/list">모임 관리</router-link>
+                </li>
+                <li :class="{'selected':(props.status==3)}">
+                    <router-link class="add-deco-img-left deco-img-user" 
+                    :class="{'deco-img-user-white':(props.status==3)}" 
+                    to="/admin/member/list">회원 관리</router-link>
+                </li>
+                <li :class="{'selected':(props.status==4)}">
+                    <router-link class="add-deco-img-left deco-img-comment" 
+                    :class="{'deco-img-comment-white':(props.status==4)}" 
+                    to="/admin/comment/list">댓글 관리</router-link>
+                </li>
+                <li :class="{'selected':(props.status==5)}">
+                    <router-link class="add-deco-img-left deco-img-report" 
+                    :class="{'deco-img-report-white':(props.status==5)}" 
+                    to="/admin/report/member">신고 관리</router-link>
+                </li>
+                <li>
+                    <a class="add-deco-img-left deco-img-logout" href="#">로그아웃</a>
+                </li>
+            </ul>
+        </nav>
+    </aside>
+</template>
+
+<script setup>
+import {ref, reactive} from 'vue';
+
+const isExpanded = ref(false);
+const props = defineProps(['status']);
+
+const clickHandler = (event) => {
+    const target = event.target;
+    if (target.tagName == 'A' || target.tagName == 'LI'){
+        return;
+    }
+    isExpanded.value = !isExpanded.value;
+}
+
+</script>
+
+<style scoped>
+.left-side-bar, .left-side-bar ul{
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    white-space: nowrap;
+    transition: all 0.2s;
+}
+
+.left-side-bar{
+    background-color: var(--white);
+    position: fixed;
+    left: 0;
+    top: 0;
+    width:3.75rem;
+    height: 100vh;
+    row-gap:2.188rem;  
+    box-shadow: 0px 3px 10px rgb(0 0 0 / 0.2);
+    padding: 0.938rem 0.375rem;
+    text-overflow: clip;
+    z-index: 10;
+}
+
+.left-side-bar > img{
+    width: fit-content;
+    flex:0 0 2.5rem;
+}
+
+.left-side-bar .deco-img-left::before{
+    background-size: 50%;
+}
+
+/* 네비게이션 영역은 이미지를 제외한 나머지 전부 */
+
+.left-side-bar > nav{
+    flex-grow: 1;
+}
+
+.left-side-bar ul{
+    height:100%;
+    row-gap: 0.5rem;
+    width:3rem;
+}
+
+.left-side-bar li{
+    color: var(--admin-icon-theme);
+    font-size: 1.5rem;
+    width:100%;
+    height:3rem;
+    border-radius: 0.625rem;
+    transition: background-color 0.3s;
+}
+
+.left-side-bar li.selected{
+    background-color: var(--admin-loyal-blue);
+}
+
+.left-side-bar li:hover{
+    background-color: var(--light-grey1);
+}
+
+
+.left-side-bar li:last-child{
+    margin-top:auto;
+}
+
+.left-side-bar li a::before{
+    width:1.5rem;
+    height:1.5rem;
+}
+
+
+/* side-bar가 펼쳐질 때의 속성 정의 */
+.left-side-bar.expended{
+    width:16.5rem;
+    padding: 0.938rem 0.875rem;
+}
+
+.left-side-bar.expended ul{
+    width:14.75rem;
+}
+
+.left-side-bar.expended li.selected{
+    font-weight: bold;
+    color:var(--white);
+}
+</style>

--- a/src/main/vue/src/components/admin/SearchBar.vue
+++ b/src/main/vue/src/components/admin/SearchBar.vue
@@ -1,0 +1,250 @@
+<template>
+    <div class="admin-search-bar-div">
+        <div class="admin-search-bar-box">
+            <form @submit.prevent="submitHandler" :action="route.path">
+                <input class="admin-search-bar" type="text" placeholder="키워드를 입력하세요" name="keyword">
+            </form>
+            <button v-if="searchOption" class="admin-search-button" @click.stop="clickHandler"></button>
+            <div class="filter-box" v-show="isOptionOpened">
+                <form @submit.prevent.stop="detailSubmitHandler" :action="route.path">
+                    <div>
+                        <span>검색어</span>
+                        <input class="keyword-input" type="text" name="keyword">
+                    </div>
+                    <div>
+                        <span>검색 옵션</span>
+                        <select name="option">
+                            <option value="title" selected>제목</option>
+                            <option value="nickname">작성자 닉네임</option>
+                            <option value="id">ID</option>
+                        </select>
+                    </div>
+                    <div>
+                        <span>기간</span>
+                        <input class="date-input" type="date" name="minDate">
+                        <span>로 부터</span>
+                        <select class="period-select" name="period">
+                            <option selected value="1">1일</option>
+                            <option value="3">3일</option>
+                            <option value="7">1주</option>
+                            <option value="30">1개월</option>
+                            <option value="90">3개월</option>
+                            <option value="180">6개월</option>
+                            <option value="360">1년</option>
+                        </select>
+                    </div>
+                    <div>
+                        <span>페이지당 결과</span>
+                        <select class="result-amount" name="num">
+                            <option value="10" selected>10개</option>
+                            <option value="20">20개</option>
+                            <option value="50">50개</option>
+                            <option value="100">100개</option>
+                        </select>
+                    </div>
+                    <div class="search-button"><input type="submit" value="검색" class="filter-button"></div>
+                </form>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+import  router from '../../router';
+const isOptionOpened = ref(false);
+const props = defineProps(['searchOption']);
+const route = useRoute();
+const clickHandler = () => {
+    isOptionOpened.value = !isOptionOpened.value;
+}
+
+const currentParams = ref({});
+
+const submitHandler = (e) => {
+    const data = new FormData(e.target);
+    const submittedParams = [...data.entries()];
+
+    const keywordParam = submittedParams[0];
+    currentParams.value.keyword = keywordParam[1];
+
+    const queryString = currentParams.toString();
+
+    const url = `${route.path}?${queryString}`;
+    // route.query;
+    router.push({
+        path: route.path,
+        query : currentParams.value,
+    });
+}
+
+const detailSubmitHandler = (e) => {
+    const data = new FormData(e.target);
+    const submittedParams = [...data.entries()];
+    const query = {};
+    submittedParams.forEach(param =>{
+        let key = param[0];
+        let value = param[1];
+        query[key] = value;
+    })
+    const queryString = query.toString();
+    currentParams.value = query;
+    const url = `${route.path}?${queryString}`;
+    // route.query;
+    router.push({
+        path: route.path,
+        query : query,
+    });
+}
+</script>
+
+<style>
+/* 검색창 css */
+
+.admin-search-bar-div{
+    width : 25rem;
+    height : 5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.admin-search-bar{
+    width: 25rem;
+    height: 3rem;
+    font-size: 1rem;
+    color:  var(--dark-grey2); 
+    outline-color:var(--light-grey2);
+    border: 0;
+    border-radius: 0.313rem;
+    background-color: var(--light-grey2);
+    background-image: url(/images/icon/search.svg);
+    background-repeat: no-repeat;
+    background-position: 4% 50%;
+    text-align: center;
+    padding:0;
+    margin:0;
+}
+
+.admin-search-bar-box{
+    width: 100%;
+    position: relative;
+}
+
+.admin-search-button{
+    position: absolute;
+    top: 0.750rem;
+    right: 0.750rem;
+    background-color: var(--light-grey2);
+    outline-color:var(--light-grey2);
+    border:none;
+    cursor: pointer;
+    background-image: url(/images/icon/slide-bar.svg);
+    height:1.500rem;
+    width:1.500rem;
+    background-repeat: no-repeat;
+
+
+}
+
+.admin-search-bar::placeholder{
+    padding-left: 0.313rem;
+    font-size: 1rem;
+    color: var(--grey2);
+    text-align : center;
+}
+
+.admin-search-bar-button{
+    width: 3rem;
+    height: 3rem;
+    background-color: var(--light-grey2);
+    border:0;
+    cursor: pointer;
+}
+
+/* 모달창 css */
+
+.filter-box{
+    position:absolute;
+    width: 44.813rem;
+    height: 20rem;
+    border: 0.063rem solid var(--black);
+    display:flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--white);
+    border: 0.063rem solid var(--grey1);
+    box-shadow: 0 0.313rem 0.313rem rgba(0, 0, 0, 0.15);
+    z-index: 3;
+}
+
+.filter-box div {
+    width: 38.813rem;
+    height: 1.563rem;
+    margin: 1.250rem auto;
+}
+
+.filter-box span{
+    display: inline-block;
+    width: 5.8rem;
+}
+
+.filter-box input,select {
+    text-align: center;
+}
+
+.filter-box input{
+    border : 0.063rem solid var(--admin-grey);
+    border-right:0; 
+    border-top:0; 
+    border-left:0; 
+}
+
+.keyword-input{
+    width: 32.375rem;
+    outline-color: var(--dark-grey2);
+}
+
+.category-select,.result-amount {
+    width: 32.375rem;
+}
+
+.date-input{
+    width:12.500rem;
+}
+
+.date-input + span {
+    margin-left:1.250rem;
+    width: 4.375rem;
+}
+
+.period-select{
+    width:12.5rem;
+    margin-left:1.250rem;
+}
+
+select{
+    border: 0.063rem solid var(--admin-grey);
+    border-right:0; 
+    border-top:0; 
+    border-left:0; 
+}
+
+.filter-button{
+    width:5.750rem;
+    height:2.375rem;
+    border:none;
+    border-radius: 0.313rem;
+    color:var(--white);
+    background-color: var(--admin-loyal-blue);
+    cursor:pointer;
+}
+
+.search-button{
+    display: flex;
+    justify-content: flex-end;
+}
+
+
+</style>

--- a/src/main/vue/src/components/admin/Table.vue
+++ b/src/main/vue/src/components/admin/Table.vue
@@ -1,0 +1,36 @@
+<template>
+    <div class="admin-table">
+        <div class="table-bar">
+            <div class="table-bar__left-container">
+                <slot name="left-buttons"></slot>
+            </div>
+            <div class="table-bar__right-container">
+                <slot name="right-buttons"></slot>
+            </div>
+        </div>
+        <div class="table-list">
+            <div class="table-list__header">
+                <slot name="list-header" class="table-list__header"></slot>
+            </div>
+            <ul class="table-list__content--wrapper">
+                <slot name="list-content"></slot>
+                <div :class="{ 'loader': !isLoaded }"></div>
+            </ul>
+        </div>
+    </div>
+</template>
+<script setup>
+const props = defineProps(['isLoaded']);
+
+</script>
+
+<style scoped>
+@import url(../../assets/css/admin/component/admin-list.css);
+
+</style>
+<script>
+</script>
+
+<style>
+
+</style>

--- a/src/main/vue/src/components/admin/modal/AdminModal.vue
+++ b/src/main/vue/src/components/admin/modal/AdminModal.vue
@@ -1,0 +1,97 @@
+<script setup>
+import { defineEmits} from "vue";
+
+const emit = defineEmits(["closeModal", "action"]);
+const props = defineProps(["modalType"]);
+
+function closeModal(e) {
+  console.log('모달 닫기');
+  // X버튼 클릭이라면 닫기
+  if (e.target.classList.contains("modal__close-btn")) {
+    emit("closeModal", props.modalType);
+    return;
+  }
+  // 모달 배경 클릭이 아니라면 return
+  if (!e.target.classList.contains("modal-default-wrap")) return;
+
+  emit("closeModal", props.modalType);
+}
+
+function action(){
+  emit("action", props.modalType);
+}
+
+
+</script>
+
+<template>
+  <section class="modal-default-wrap" @click="closeModal($event)">
+    <div class="modal-default">
+      <div class="modal__header">
+        <slot name="modal-header"></slot>
+        <span class="icon icon-x-white pointer modal__close-btn">
+        </span>
+      </div>
+      <div class="modal__body">
+        <slot name="modal-body"></slot>
+      </div>
+      <div class="modal__footer">
+        <span class="btn btn-round btn-action" @click="action">확인</span>
+        <span class="btn btn-round" @click="closeModal($event)">취소</span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.modal-default-wrap {
+  background-color: rgba(0, 0, 0, 0.15);
+  position: fixed;
+  inset: 0; /*t, l, b, r 0*/
+}
+
+.modal-default {
+  position: relative;
+  top: 25%;
+  max-width: 460px;
+  min-height: 400px;
+  height: fit-content;
+  background-color: white;
+  margin: 0 auto;
+  border: 1px solid #c4c4c4;
+  box-shadow: 0px 3px 8px rgba(0, 0, 0, 0.25);
+  border-radius: 10px;
+  font-size: 18px;
+  z-index: 999;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 16px;
+  height:40px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  background-color: var(--admin-loyal-blue);
+}
+
+.modal__body {
+  display: flex;
+  justify-content: center;
+  padding: 30px 16px 24px 16px;
+  color: var(--dark-grey1);
+  flex-direction: column;
+}
+
+
+.modal__footer{
+  display:flex;
+  justify-content: center;
+  column-gap:10px;
+}
+
+.btn-action {
+    background-color: var(--admin-loyal-blue);
+}
+</style>

--- a/src/main/vue/src/router/admin.js
+++ b/src/main/vue/src/router/admin.js
@@ -1,12 +1,47 @@
 import AdminLayout from "@/views/admin/Layout.vue";
+import AdminHome from "@/views/admin/Home.vue";
+import AdminMeeting from "@/views/admin/meeting/Meeting.vue";
+import AdminNotification from "@/views/admin/notification.vue";
+import AdminReport from "@/views/admin/report/Report.vue";
+import AdminMemberReport from "@/views/admin/report/Member.vue";
+import AdminMeetingReport from "@/views/admin/report/Meeting.vue";
+import AdminCommentReport from "@/views/admin/report/Comment.vue";
+import AdminMeetingList from "@/views/admin/meeting/List.vue";
+import AdminCategory from "@/views/admin/meeting/Category.vue";
+import AdminRegion from "@/views/admin/meeting/Region.vue";
+import AdminComment from "@/views/admin/comment/Comment.vue";
+import AdminCommentList from "@/views/admin/comment/List.vue";
+import AdminMember from "@/views/admin/member/Member.vue";
+import AdminMemberList from "@/views/admin/member/List.vue";
+import AdminEvaluation from "@/views/admin/member/Evaluation.vue";
+import AdminParticipation from "@/views/admin/member/Participation.vue";
 
 export default {
   path: "/admin/",
   component: AdminLayout,
   children: [
-    //TODO: 관리자
-    /*
+  //   //TODO: 관리자
       { path: "home", component: AdminHome },
-    */
+      { path: "meeting", component: AdminMeeting, children: [
+        { path: "list", component: AdminMeetingList },
+        { path: "category", component: AdminCategory },
+        { path: "region", component: AdminRegion },
+      ]},
+      { path: "member", component: AdminMember, children: [
+        { path: "list", component: AdminMemberList },
+        { path: "eval", component: AdminEvaluation },
+        { path: "participation", component: AdminParticipation },
+      ]},
+      { path: "notification", component: AdminNotification, children: [
+  //       { path: "list", component: AdminHome },
+      ]},
+      { path: "report", component: AdminReport, children: [
+        { path: "member", component: AdminMemberReport },
+        { path: "meeting", component: AdminMeetingReport },
+        { path: "comment", component: AdminCommentReport },
+      ]},
+      { path: "comment", component: AdminComment, children: [
+        { path: "list", component: AdminCommentList },
+      ]},
   ],
 };

--- a/src/main/vue/src/views/admin/Home.vue
+++ b/src/main/vue/src/views/admin/Home.vue
@@ -1,0 +1,15 @@
+<template>
+    <Category/>
+    <AdminList/>
+</template>
+
+<script setup>
+const emit = defineEmits(["menuChanged"]);
+emit("menuChanged", "home");
+
+
+</script>
+
+<style>
+
+</style>

--- a/src/main/vue/src/views/admin/Layout.vue
+++ b/src/main/vue/src/views/admin/Layout.vue
@@ -1,15 +1,64 @@
-<script>
-import Header from "./Hader.vue";
-export default {
-  components: {
-    Header,
-  },
-};
+<script setup>
+import Header from "../../components/admin/Header.vue";
+import {ref} from 'vue';
+
+const currentMenuStatus = ref(0);
+
+const changeHeaderSelected = (menu) => {
+  let value;
+  switch(menu){
+    case "home":
+    value = 0;
+    break;
+    case "notification":
+    value = 1;
+    break;
+    case "meeting":
+    value = 2;
+    break;
+    case "member":
+    value = 3;
+    break;
+    case "comment":
+    value = 4;
+    break;
+    case "report":
+    value = 5;
+    break;
+  }
+  currentMenuStatus.value = value;
+}
+
+
 </script>
 
 <template>
-  <Header />
-  <router-view></router-view>
+    <div class="main-wrapper">
+      <main>
+        <router-view @menuChanged="changeHeaderSelected"></router-view>
+        <Header :status="currentMenuStatus"/>
+      </main>
+    </div>
 </template>
 
-<style></style>
+<style>
+@import url(../../assets/css/admin/component/status.css);
+@import url(../../assets/css/admin/component/button.css);
+@import url(../../assets/css/admin/component/admin-list.css);
+@import url(../../assets/css/admin/component/table-bar.css);
+@import url(../../assets/css/admin/component/select.css);
+
+.main-wrapper{
+  margin-top: 30px;
+  margin-left:97px;
+  margin-right:57px;
+  display: flex;
+}
+
+main{
+  flex-grow: 1;
+  margin-left: auto;
+  margin-right: auto;
+  padding-bottom: 1rem;
+}
+</style>

--- a/src/main/vue/src/views/admin/report/Comment.vue
+++ b/src/main/vue/src/views/admin/report/Comment.vue
@@ -170,8 +170,8 @@ const updateUrl = () => {
 }
 
 watch(route, () => {
-    requestData();
     updateOption();
+    requestData();
 })
 
 

--- a/src/main/vue/src/views/admin/report/Comment.vue
+++ b/src/main/vue/src/views/admin/report/Comment.vue
@@ -1,0 +1,335 @@
+<template>
+    <search-bar :searchOption="true" />
+    <admin-table @search="searchHandler" :isLoaded="listData.isLoaded">
+        <template #left-buttons>
+            <input @click="checkAllHandler" class="checkbox" type="checkbox" name="table-checkbox" />
+            <span @click="banMember" class="table-bar__icon table-bar__icon--user-ban"></span>
+            <span @click="suspendMember" class="table-bar__icon table-bar__icon--user-suspend"></span>
+            <span @click="cancelReport" class="table-bar__icon table-bar__icon--user-check"></span>
+        </template>
+        <template #right-buttons>
+            <span class="table-bar__page"> {{`${listData.count.toLocaleString()} 개 중 ` + getMinMaxIndex }} </span>
+            <span @click="decreasePage" class="table-bar__icon table-bar__icon-arrow-left hide"></span>
+            <span @click="increasePage" class="table-bar__icon table-bar__icon-arrow-right hide"></span>
+        </template>
+        <template #list-header>
+            <ul>
+                <li><span>ID</span>
+                    <button @click="reverseOrder">
+                        <img src="/images/icon/up-down.svg" alt="">
+                    </button>
+                </li>
+                <li class="admin-tb-2">신고자</li>
+                <li class="admin-tb-3">댓글 내용 / 작성자 닉네임(id)</li>
+                <li class="admin-tb-2">종류</li>
+                <li class="admin-tb-3">신고사유</li>
+                <li class="admin-tb-2">신고일자</li>
+                <li class="admin-tb-1">처리여부</li>
+            </ul>
+        </template>
+        <template #list-content>
+            <li v-for="(item, index) in listData.reportedComments" :key="index" class="table-list__content">
+                <ul class="list-content">
+                    <li class="list-content__id">
+                        <input type="checkbox" class="checkbox" v-model="isChecked[index]">
+                        <span>{{ item.id }}</span>
+                    </li>
+                    <li class="list-content__reporter admin-tb-2">
+                        {{ `${item.reporterNickname}(${item.reporterId})` }}
+                    </li>
+                    <li class="admin-tb-3 list-content__comment-content">
+                        <div>{{ item.original }}</div>
+                        <div>{{ `${item.writerNickname}(${item.writerId})` }}</div>
+                    </li>
+                    <li class="admin-tb-2">{{ item.reportType }}</li>
+                    <li class="admin-tb-3">{{ item.reason }}</li>
+                    <li class="list-content_date admin-tb-2">{{ item.createdAt }}</li>
+                    <li class="list-content__status admin-tb-1">
+                        <span class="status status--round"
+                            :class="item.processedAt ? 'status--positive' : 'status--negative'">
+                            {{(item.processedAt) ? 'TRUE' : 'FALSE'}}
+                        </span>
+                    </li>
+                </ul>
+            </li>
+        </template>
+    </admin-table>
+</template>
+
+<script setup>
+import SearchBar from '../../../components/admin/SearchBar.vue';
+import AdminTable from '../../../components/admin/Table.vue';
+import { computed, reactive, ref, watch } from 'vue';
+import router from '../../../router'
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+
+
+const listData = reactive({
+    reportedComments: [],
+    count: 0,
+    isLoaded: false,
+});
+
+
+let { keyword, option, page = 1, num = 10, minDate = new Date().toISOString().slice(0, 10), period = 9999 } = route.query;
+
+const searchOption = reactive({
+    keyword: String,
+    option: String,
+    page: Number,
+    num: Number,
+    minDate: String,
+    period: Number,
+    order: String,
+})
+
+const reverseOrder = () => {
+    if (searchOption.order == "desc") {
+        searchOption.order = "asc";
+    }
+    else {
+        searchOption.order = "desc";
+    }
+    updateUrl();
+}
+
+const updateOption = () => {
+    let { keyword, option, page = 1, num = 10, minDate = new Date().toISOString().slice(0, 10),
+        period = 9999, order = "desc" } = route.query;
+
+    searchOption.keyword = keyword;
+    searchOption.option = option;
+    searchOption.page = page;
+    searchOption.num = num;
+    searchOption.minDate = minDate;
+    searchOption.period = period;
+    searchOption.order = order;
+}
+updateOption();
+
+const isChecked = reactive([]);
+
+const checkAllHandler = (event) => {
+    let allCheckboxChecked = event.target.checked;
+
+    for (let index in isChecked) {
+        isChecked[index] = allCheckboxChecked;
+    }
+}
+
+const pageMinIndex = () => {
+    const pageMaxNum = (searchOption.page - 1) * searchOption.num + 1;
+    return (pageMaxNum <= listData.count ? pageMaxNum : listData.count);
+}
+
+const pageMaxIndex = () => {
+    const pageMaxNum = (searchOption.page * searchOption.num);
+    return (pageMaxNum <= listData.count ? pageMaxNum : listData.count);
+}
+
+const getMinMaxIndex = computed(() => {
+    return `${pageMinIndex().toLocaleString()}-${pageMaxIndex().toLocaleString()}`
+})
+
+const decreasePage = () => {
+    if (pageMinIndex() == 0 || pageMinIndex() == 1) {
+        return;
+    }
+
+    if (!listData.isLoaded) {
+        return;
+    }
+    searchOption.page--;
+    listData.isLoaded = false;
+    updateUrl();
+}
+
+const increasePage = () => {
+    if (pageMaxIndex() == listData.count) {
+        return;
+    }
+    if (!listData.isLoaded) {
+        return;
+    }
+    searchOption.page++;
+    listData.isLoaded = false;
+    updateUrl();
+}
+
+const closeDetailModal = () => {
+    meetingDetails.isLoaded = false;
+}
+
+const updateUrl = () => {
+    router.push({
+        path: route.path,
+        query: searchOption,
+    });
+}
+
+watch(route, () => {
+    requestData();
+    updateOption();
+})
+
+
+const requestData = () => {
+    listData.isLoaded = false;
+    isChecked.length = 0;
+
+    fetch(`/api/${route.path}${window.location.search}`)
+        .then(res => res.json())
+        .then(data => {
+            listData.reportedComments = [];
+            listData.count = data.count;
+            data.reportedComments.forEach(item => {
+                listData.reportedComments.push(item)
+                isChecked.push(false);
+            });
+            listData.isLoaded = true;
+        })
+}
+requestData();
+
+
+const banMember = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedComments();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    if (!confirm(`정말로 다음 사용자를 영구정지하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}\n해당 사용자가 작성한 신고 대상 댓글은 모두 삭제됩니다.`)) return
+    const url = `/api/admin/report/comment?ids=${ids}`
+    const formData = new FormData();
+    formData.append('period', '9999');
+    const option = {
+        method: 'PUT',
+        body: formData,
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('영구 정지가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다' + err);
+        })
+}
+
+const suspendMember = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedComments();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    let period = prompt('일시정지 기간을 입력해주세요.');
+    if (period == null) return;
+
+    period = parseInt(period);
+    const blockedAt = new Date();
+    const releasedAt = new Date();
+    releasedAt.setDate(releasedAt.getDate() + period);
+    if (isNaN(period)) {
+        alert('숫자만 입력해주세요!');
+        return;
+    }
+    if (!confirm(`정말로 다음 사용자를 일시정지하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}\n정지기간: ${blockedAt.toLocaleDateString()} ~ ${releasedAt.toLocaleDateString()}\n해당 사용자가 작성한 신고 대상 댓글은 모두 삭제됩니다.`)) return
+    const url = `/api/admin/report/comment?ids=${ids}`
+    const formData = new FormData();
+    formData.append('period', period);
+    const option = {
+        method: 'PUT',
+        body: formData,
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('일시 정지가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다' + err);
+        })
+}
+
+const cancelReport = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedComments();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    if (!confirm(`정말로 다음 신고 내용을 취소처리하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}\n취소 이후에는 삭제처리된 댓글이 복구되고, 계정정지상태가 취소됩니다.`)) return
+    const url = `/api/admin/report/comment?ids=${ids}`
+    const option = {
+        method: 'DELETE'
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('신고 취소가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다' + err);
+        })
+}
+
+function getCheckedIds() {
+    let ids = [];
+    for (let index in isChecked) {
+        if (isChecked[index]) {
+            const reportedComment = listData.reportedComments[index];
+            ids.push(reportedComment.id);
+        }
+    }
+    return ids;
+}
+
+function getCheckedReportedComments() {
+    let members = new Set();
+    for (let index in isChecked) {
+        if (isChecked[index]) {
+            const reportedComment = listData.reportedComments[index];
+            members.add(`${reportedComment.writerNickname}(${reportedComment.writerId})`);
+        }
+    }
+    return members;
+}
+
+
+
+</script>
+
+<style scoped>
+.list-content__comment-content {
+    flex-direction: column;
+}
+
+.list-content__reporter {
+    align-items: center;
+}
+</style>

--- a/src/main/vue/src/views/admin/report/Meeting.vue
+++ b/src/main/vue/src/views/admin/report/Meeting.vue
@@ -1,0 +1,470 @@
+<template>
+    <search-bar :searchOption="true" />
+    <admin-table @search="searchHandler" :isLoaded="listData.isLoaded">
+        <template #left-buttons>
+            <input @click="checkAllHandler" class="checkbox" type="checkbox" name="table-checkbox" />
+            <span @click="banMember" class="table-bar__icon table-bar__icon--user-ban"></span>
+            <span @click="suspendMember" class="table-bar__icon table-bar__icon--user-suspend"></span>
+            <span @click="cancelReport" class="table-bar__icon table-bar__icon--user-check"></span>
+        </template>
+        <template #right-buttons>
+            <span class="table-bar__page"> {{`${listData.count.toLocaleString()} 개 중 ` + getMinMaxIndex }} </span>
+            <span @click="decreasePage" class="table-bar__icon table-bar__icon-arrow-left hide"></span>
+            <span @click="increasePage" class="table-bar__icon table-bar__icon-arrow-right hide"></span>
+        </template>
+        <template #list-header>
+            <ul>
+                <li><span>ID</span>
+                    <button @click="reverseOrder">
+                        <img src="/images/icon/up-down.svg" alt="">
+                    </button>
+                </li>
+                <li class="admin-tb-3">신고자(id)</li>
+                <li class="admin-tb-3">모임글 제목/작성자 닉네임(id)</li>
+                <li class="admin-tb-3">종류</li>
+                <li class="admin-tb-1">신고일자</li>
+                <li class="admin-tb-1">처리 여부</li>
+            </ul>
+        </template>
+        <template #list-content>
+            <li v-for="(item, index) in listData.reportedMeetings" :key="index" class="table-list__content">
+                <ul class="list-content">
+                    <li class="list-content__id">
+                        <input type="checkbox" class="checkbox" v-model="isChecked[index]">
+                        <span>{{ item.id }}</span>
+                    </li>
+                    <li class="list-content__reporter admin-tb-3"> {{ `${item.reporterNickname}(${item.reporterId})` }}
+                    </li>
+                    <li class="list-content__reported admin-tb-3">
+                        <div>{{ item.meetingTitle }}</div>
+                        <div> {{ `${item.writerNickname}(${item.writerId})` }}</div>
+                    </li>
+                    <li class="admin-tb-3">{{ item.reportType }} </li>
+                    <li class="admin-tb-1">{{ item.createdAt }}</li>
+                    <li class="list-content__status admin-tb-1">
+                        <span class="status status--round"
+                            :class="item.processedAt ? 'status--positive' : 'status--negative'">
+                            {{(item.processedAt) ? 'TRUE' : 'FALSE'}}
+                        </span>
+                    </li>
+                </ul>
+            </li>
+        </template>
+    </admin-table>
+    <!-- <Modal @closeModal="closeModal" v-show="modalState.ban" :modalType="'ban'">
+        <template #modal-header>
+            <span class="admin-report-name bold">영구 정지 확인</span>
+        </template>
+        <template #modal-body>
+            <div>
+                <div class="admin-report-icon admin-report-icon--user-ban"></div>
+                <span>정말로 다음 사용자를 영구정지하시겠습니까?</span>
+            </div>
+            <div class="reported-member">
+                <div>사용자 : </div>
+                <div>
+                    <span v-for="(item, index) in members"></span>
+                </div>
+            </div>
+        </template>
+        <template #modal-footer>
+            <span class="btn btn-round btn-action">확인</span>
+            <span class="btn btn-round">취소</span>
+        </template>
+    </Modal>
+    <Modal @closeModal="closeModal" v-show="modalState.suspendInput" :modalType="'suspendInput'">
+        <template #modal-header>
+            <span class="admin-report-name bold">정지 기간 설정</span>
+        </template>
+        <template #modal-body>
+            <div>
+                <div>
+                    <div class="admin-report-icon admin-report-icon--user-ban"></div>
+                    <span>활동 정지 기간을 설정해주세요</span>
+                </div>
+                <div class="reported-member">
+                    <div>사용자 : </div>
+                    <div>
+                        <span v-for="(item, index) in members"></span>
+                    </div>
+                </div>
+                <div>
+                    <span>정지기간 : </span><input type="number" placeholder="기간입력 (단위: 일)">
+                </div>
+            </div>
+        </template>
+        <template #modal-footer>
+            <span class="btn btn-round btn-action">확인</span>
+            <span class="btn btn-round">취소</span>
+        </template>
+    </Modal>
+    <Modal @closeModal="closeModal" v-show="modalState.suspendConfirm" :modalType="'suspendConfirm'">
+        <template @closeModal="closeModal" #modal-header>
+            <span class="admin-report-name bold">영구 정지 확인</span>
+        </template>
+        <template #modal-body>
+            <div>
+                <div>
+                    <div class="admin-report-icon admin-report-icon--user-ban"></div>
+                    <span>정말로 다음 회원을 기간 정지하겠습니까?</span>
+                </div>
+                <div class="reported-member">
+                    <div>사용자 : </div>
+                    <div>
+                        <span v-for="(item, index) in members"></span>
+                    </div>
+                </div>
+                <div>
+                    <span>{{ `정지기간 : ${startDate} ~ ${endDate}` }}</span>
+                </div>
+            </div>
+        </template>
+        <template #modal-footer>
+            <span class="btn btn-round btn-action">확인</span>
+            <span class="btn btn-round">취소</span>
+        </template>
+    </Modal>
+    <Modal @closeModal="closeModal" v-show="modalState.check" :modalType="'check'">
+        <template #modal-header>
+            <span class="admin-report-name bold">영구 정지 확인</span>
+        </template>
+        <template #modal-body>
+            <div>
+                <div class="admin-report-icon admin-report-icon--user-ban"></div>
+                <span>정말로 다음 사용자를 영구정지하시겠습니까?</span>
+            </div>
+            <div class="reported-member">
+                <div>사용자 : </div>
+                <div>
+                    <span v-for="(item, index) in members"></span>
+                </div>
+            </div>
+        </template>
+    </Modal> -->
+</template>
+
+<script setup>
+import SearchBar from '../../../components/admin/SearchBar.vue';
+import AdminTable from '../../../components/admin/Table.vue';
+import Modal from '../../../components/admin/modal/AdminModal.vue';
+import { computed, reactive, ref, watch } from 'vue';
+import router from '../../../router'
+import { useRoute } from 'vue-router';
+import DetailModal from '../../../components/admin/modal/AdminDetailModal.vue';
+
+const currentSelect = reactive({
+    details: null
+})
+
+const modalState = reactive({
+    ban: true,
+    suspendInput: true,
+    suspendConfirm: true,
+    check: true,
+})
+
+const route = useRoute();
+
+
+const listData = reactive({
+    reportedMeetings: [],
+    count: 0,
+    isLoaded: false,
+});
+
+const searchOption = reactive({
+    keyword: String,
+    option: String,
+    page: Number,
+    num: Number,
+    minDate: String,
+    period: Number,
+    order: String,
+})
+
+const reverseOrder = () => {
+    if (searchOption.order == "desc") {
+        searchOption.order = "asc";
+    }
+    else {
+        searchOption.order = "desc";
+    }
+    updateUrl();
+}
+
+const updateOption = () => {
+    let { keyword, option, page = 1, num = 10, minDate = new Date().toISOString().slice(0, 10),
+        period = 9999, order = "desc" } = route.query;
+
+    searchOption.keyword = keyword;
+    searchOption.option = option;
+    searchOption.page = page;
+    searchOption.num = num;
+    searchOption.minDate = minDate;
+    searchOption.period = period;
+    searchOption.order = order;
+}
+updateOption();
+
+const isChecked = reactive([]);
+
+const checkAllHandler = (event) => {
+    let allCheckboxChecked = event.target.checked;
+
+    for (let index in isChecked) {
+        isChecked[index] = allCheckboxChecked;
+    }
+}
+
+const pageMinIndex = () => {
+    const pageMaxNum = (searchOption.page - 1) * searchOption.num + 1;
+    return (pageMaxNum <= listData.count ? pageMaxNum : listData.count);
+}
+
+const pageMaxIndex = () => {
+    const pageMaxNum = (searchOption.page * searchOption.num);
+    return (pageMaxNum <= listData.count ? pageMaxNum : listData.count);
+}
+
+const getMinMaxIndex = computed(() => {
+    return `${pageMinIndex().toLocaleString()}-${pageMaxIndex().toLocaleString()}`
+})
+
+const decreasePage = () => {
+    if (pageMinIndex() == 0 || pageMinIndex() == 1) {
+        return;
+    }
+
+    if (!listData.isLoaded) {
+        return;
+    }
+    searchOption.page--;
+    listData.isLoaded = false;
+    updateUrl();
+}
+
+const increasePage = () => {
+    if (pageMaxIndex() == listData.count) {
+        return;
+    }
+    if (!listData.isLoaded) {
+        return;
+    }
+    searchOption.page++;
+    listData.isLoaded = false;
+    updateUrl();
+}
+
+const closeDetailModal = () => {
+    meetingDetails.isLoaded = false;
+}
+
+const updateUrl = () => {
+    router.push({
+        path: route.path,
+        query: searchOption,
+    });
+}
+
+watch(route, () => {
+    updateOption();
+    requestData();
+})
+
+const requestData = () => {
+    listData.isLoaded = false;
+    isChecked.length = 0;
+
+    fetch(`/api/${route.path}${window.location.search}`)
+        .then(res => res.json())
+        .then(data => {
+            listData.reportedMeetings = [];
+            listData.count = data.count;
+            data.reportedMeetings.forEach(item => {
+                listData.reportedMeetings.push(item)
+                isChecked.push(false);
+            });
+            listData.isLoaded = true;
+        })
+}
+requestData();
+
+const closeModal = (modalType) => {
+    console.log(modalType);
+    modalState[modalType] = false;
+}
+
+const banMember = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedMembers();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    if (!confirm(`정말로 다음 사용자를 영구정지하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}\n해당 사용자가 작성한 신고 대상 글은 모두 삭제됩니다.`)) return
+    const url = `/api/admin/report/meeting?ids=${ids}`
+    const formData = new FormData();
+    formData.append('period', '9999');
+    const option = {
+        method: 'PUT',
+        body: formData,
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('영구 정지가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다');
+        })
+}
+
+const suspendMember = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedMembers();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    let period = prompt('일시정지 기간을 입력해주세요.');
+    if (period == null) return;
+
+    period = parseInt(period);
+    const blockedAt = new Date();
+    const releasedAt = new Date();
+    releasedAt.setDate(releasedAt.getDate() + period);
+    if (isNaN(period)) {
+        alert('숫자만 입력해주세요!');
+        return;
+    }
+    if (!confirm(`정말로 다음 사용자를 일시정지하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}\n정지기간: ${blockedAt.toLocaleDateString()} ~ ${releasedAt.toLocaleDateString()}\n해당 사용자가 작성한 신고 대상 글은 모두 삭제됩니다.`)) return
+    const url = `/api/admin/report/meeting?ids=${ids}`
+    const formData = new FormData();
+    formData.append('period', period);
+    const option = {
+        method: 'PUT',
+        body: formData,
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('일시 정지가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다' + err);
+        })
+}
+
+const cancelReport = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedMembers();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    if (!confirm(`정말로 다음 신고 내용을 취소처리하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}\n취소 이후에는 삭제처리된 글이 복구되고, 계정정지상태가 취소됩니다.`)) return
+    const url = `/api/admin/report/meeting?ids=${ids}`
+    const option = {
+        method: 'DELETE'
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('신고 취소가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다' + err);
+        })
+}
+
+function getCheckedIds() {
+    let ids = [];
+    for (let index in isChecked) {
+        if (isChecked[index]) {
+            const reportedMeeting = listData.reportedMeetings[index];
+            ids.push(reportedMeeting.id);
+        }
+    }
+    return ids;
+}
+
+function getCheckedReportedMembers() {
+    let members = new Set();
+    for (let index in isChecked) {
+        if (isChecked[index]) {
+            const reportedMeeting = listData.reportedMeetings[index];
+            members.add(`${reportedMeeting.writerNickname}(${reportedMeeting.writerId})`);
+        }
+    }
+    return members;
+}
+
+</script>
+
+<style scoped>
+.list-content__reported {
+    flex-direction: column;
+}
+
+.admin-report-icon {
+    width: 100px;
+    height: 100px;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+}
+
+.admin-report-icon--user-ban {
+    background-image: url(/images/icon/user-ban.svg);
+}
+
+.admin-report-icon--user-check {
+    background-image: url(/images/icon/user-check.svg);
+}
+
+.admin-report-icon--user-suspend {
+    background-image: url(/images/icon/user-suspend.svg);
+}
+
+
+
+.admin-report-name {
+    margin-right: auto;
+    color: white;
+}
+
+.reported-member {
+    display: flex;
+}
+
+.reported-member>div:nth-child(1)>span {
+    color: var(--red);
+}
+
+.modal__body>div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+</style>

--- a/src/main/vue/src/views/admin/report/Member.vue
+++ b/src/main/vue/src/views/admin/report/Member.vue
@@ -1,0 +1,318 @@
+<template>
+    <search-bar :searchOption="true"/>
+    <admin-table @search="searchHandler" :isLoaded="listData.isLoaded">
+        <template #left-buttons>
+            <input @click="checkAllHandler" class="checkbox" type="checkbox" name="table-checkbox"/>
+            <span @click="banMember" class="table-bar__icon table-bar__icon--user-ban"></span>
+            <span @click="suspendMember" class="table-bar__icon table-bar__icon--user-suspend"></span>
+            <span @click="cancelReport" class="table-bar__icon table-bar__icon--user-check"></span>
+        </template>
+        <template #right-buttons>
+            <span class="table-bar__page"> {{`${listData.count.toLocaleString()} 개 중 ` + getMinMaxIndex }} </span>
+            <span @click="decreasePage" class="table-bar__icon table-bar__icon-arrow-left hide"></span>
+            <span @click="increasePage" class="table-bar__icon table-bar__icon-arrow-right hide"></span>
+        </template>
+        <template #list-header>
+            <ul>
+                <li><span>ID</span>
+                    <button @click="reverseOrder">
+                        <img src="/images/icon/up-down.svg" alt="">
+                    </button>
+                </li>
+                <li class="admin-tb-2">신고자(id)</li>
+                <li class="admin-tb-2">신고대상(id)</li>
+                <li class="admin-tb-2">종류</li>
+                <li class="admin-tb-3">신고사유</li>
+                <li class="admin-tb-2">신고일자</li>
+                <li class="admin-tb-1">처리여부</li>
+            </ul>
+        </template>
+        <template #list-content>
+            <li v-for="(item, index) in listData.reportedMembers" :key="index" class="table-list__content">
+                <ul class="list-content">
+                    <li class="list-content__id">
+                        <input type="checkbox" class="checkbox" v-model="isChecked[index]">
+                        <span>{{ item.id }}</span>
+                    </li>
+                    <li class="list-content__reporter admin-tb-2"> {{ `${item.reporterNickname}(${item.reporterId})` }} </li>
+                    <li class="list-content__reported admin-tb-2">{{ `${item.reportedNickname}(${item.reportedId})` }}</li>
+                    <li class="admin-tb-2">{{ item.reportType}} </li>
+                    <li class="admin-tb-3">{{ item.reason }}</li>
+                    <li class="list-content_date admin-tb-2">{{ item.createdAt }}</li>
+                    <li class="list-content__status admin-tb-1">
+                        <span class="status status--round" :class="item.processedAt ? 'status--positive' : 'status--negative'">
+                            {{(item.processedAt) ? 'TRUE' : 'FALSE'}}
+                        </span>
+                    </li>
+                </ul>
+            </li>
+        </template>
+    </admin-table>
+</template>
+
+<script setup>
+import SearchBar from '../../../components/admin/SearchBar.vue';
+import AdminTable from '../../../components/admin/Table.vue';
+import { computed, reactive, ref, watch } from 'vue';
+import router from '../../../router'
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+
+
+const listData = reactive({
+    reportedMembers: [],
+    count: 0,
+    isLoaded: false,
+});
+
+const searchOption = reactive({
+    keyword: String,
+    option: String,
+    page: Number,
+    num: Number,
+    minDate: String,
+    period: Number,
+    order: String,
+})
+
+const reverseOrder = () => {
+    if (searchOption.order == "desc") {
+        searchOption.order = "asc";
+    }
+    else {
+        searchOption.order = "desc";
+    }
+    updateUrl();
+}
+
+const updateOption = () => {
+    let { keyword, option, page = 1, num = 10, minDate = new Date().toISOString().slice(0, 10),
+        period = 9999, order = "desc" } = route.query;
+
+    searchOption.keyword = keyword;
+    searchOption.option = option;
+    searchOption.page = page;
+    searchOption.num = num;
+    searchOption.minDate = minDate;
+    searchOption.period = period;
+    searchOption.order = order;
+}
+updateOption();
+
+const isChecked = reactive([]);
+
+const checkAllHandler = (event) => {
+    let allCheckboxChecked = event.target.checked;
+
+    for (let index in isChecked) {
+        isChecked[index] = allCheckboxChecked;
+    }
+}
+
+const pageMinIndex = () => {
+    const pageMaxNum = (searchOption.page - 1) * searchOption.num + 1;
+    return (pageMaxNum <= listData.count ? pageMaxNum : listData.count);
+}
+
+const pageMaxIndex = () => {
+    const pageMaxNum = (searchOption.page * searchOption.num);
+    return (pageMaxNum <= listData.count ? pageMaxNum : listData.count);
+}
+
+const getMinMaxIndex = computed(() => {
+    return `${pageMinIndex().toLocaleString()}-${pageMaxIndex().toLocaleString()}`
+})
+
+const decreasePage = () => {
+    if (pageMinIndex() == 0 || pageMinIndex() == 1) {
+        return;
+    }
+
+    if (!listData.isLoaded) {
+        return;
+    }
+    searchOption.page--;
+    listData.isLoaded = false;
+    updateUrl();
+}
+
+const increasePage = () => {
+    if (pageMaxIndex() == listData.count) {
+        return;
+    }
+    if (!listData.isLoaded) {
+        return;
+    }
+    searchOption.page++;
+    listData.isLoaded = false;
+    updateUrl();
+}
+
+const closeDetailModal = () => {
+    meetingDetails.isLoaded = false;
+}
+
+const updateUrl = () => {
+    router.push({
+        path: route.path,
+        query: searchOption,
+    });
+}
+
+watch(route, () => {
+    updateOption();
+    requestData();
+})
+
+
+const requestData = () => {
+    listData.isLoaded = false;
+    isChecked.length = 0;
+
+    fetch(`/api/admin/report/member${window.location.search}`)
+        .then(res => res.json())
+        .then(data => {
+            listData.reportedMembers = [];
+
+            listData.count = data.count;
+            data.reportedMembers.forEach(item => {
+                listData.reportedMembers.push(item)
+                isChecked.push(false);
+            });
+            listData.isLoaded = true;
+        })
+}
+
+requestData();
+
+const banMember = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedMembers();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    if (!confirm(`정말로 다음 사용자를 영구정지하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}`)) return
+    const url = `/api/admin/report/member?ids=${ids}`
+    const formData = new FormData();
+    formData.append('period', '9999');
+    const option = {
+        method: 'PUT',
+        body: formData,
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('영구 정지가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다');
+        })
+}
+
+
+const suspendMember = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedMembers();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    let period = prompt('일시정지 기간을 입력해주세요.');
+    if (period == null) return;
+
+    period = parseInt(period);
+    const blockedAt = new Date();
+    const releasedAt = new Date();
+    releasedAt.setDate(releasedAt.getDate() + period);
+    if (isNaN(period)) {
+        alert('숫자만 입력해주세요!');
+        return;
+    }
+    if (!confirm(`정말로 다음 사용자를 일시정지하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}\n정지기간: ${blockedAt.toLocaleDateString()} ~ ${releasedAt.toLocaleDateString()}\n`)) return
+    const url = `/api/admin/report/member?ids=${ids}`
+    const formData = new FormData();
+    formData.append('period', period);
+    const option = {
+        method: 'PUT',
+        body: formData,
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('일시 정지가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다' + err);
+        })
+}
+
+const cancelReport = () => {
+    const ids = getCheckedIds();
+    const members = getCheckedReportedMembers();
+
+    if (ids.length == 0) {
+        alert('선택한 신고항목이 없습니다.');
+        return;
+    }
+
+    if (!confirm(`정말로 다음 신고 내용을 취소처리하시겠습니까?\n신고번호: ${ids}\n신고대상: ${[...members].join(', ')}\n취소 이후에는 계정정지상태가 취소됩니다.`)) return
+    const url = `/api/admin/report/member?ids=${ids}`
+    const option = {
+        method: 'DELETE'
+    }
+    fetch(url, option)
+        .then(res => {
+            if (res.ok) {
+                alert('신고 취소가 정상적으로 처리되었습니다.')
+                requestData();
+            }
+            else {
+                throw new Error();
+            }
+        })
+        .catch(err => {
+            alert('신고처리 과정에서 오류가 발생하였습니다' + err);
+        })
+}
+
+function getCheckedIds() {
+    let ids = [];
+    for (let index in isChecked) {
+        if (isChecked[index]) {
+            const reportedMember = listData.reportedMembers[index];
+            ids.push(reportedMember.id);
+        }
+    }
+    return ids;
+}
+
+function getCheckedReportedMembers() {
+    let members = new Set();
+    for (let index in isChecked) {
+        if (isChecked[index]) {
+            const reportedMember = listData.reportedMembers[index];
+            members.add(`${reportedMember.reportedNickname}(${reportedMember.reportedId})`);
+        }
+    }
+    return members;
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/main/vue/src/views/admin/report/Report.vue
+++ b/src/main/vue/src/views/admin/report/Report.vue
@@ -1,0 +1,54 @@
+<template>
+    <Category :categories="categories" :categoryStatus="categoryStatus"/>
+    <router-view/>
+</template>
+
+<script setup>
+import {ref, watch} from 'vue';
+import Category from '../../../components/admin/Category.vue';
+import { useRoute } from 'vue-router';
+const emit = defineEmits(["menuChanged"]);
+emit("menuChanged", "report");
+
+const categoryStatus = ref(0);
+const route = useRoute();
+const categories = [
+    {
+        name: '회원신고 관리',
+        link: 'member'
+    }, 
+    {
+        name: '모임신고 관리',
+        link: 'meeting'
+    }, 
+    {
+        name: '댓글신고 관리',
+        link: 'comment',
+    }
+];
+
+watch(route, () => changeCategory(route.path.split('/')[3]));
+
+const changeCategory = (category) => {
+    let value;
+    switch(category){
+        case "member":
+        value = 0;
+        break;
+        case "meeting":
+        value = 1;
+        break;
+        case "comment":
+        value = 2;
+        break;
+    }
+    categoryStatus.value = value;
+}
+
+changeCategory(route.path.split('/')[3]);
+
+</script>
+
+<style>
+
+</style>


### PR DESCRIPTION
## 🛠 작업사항
- 관리자 페이지 기본 레이아웃 및 라우팅 추가
- 관리자 신고 기능 추가하였음 (사용자, 모임글, 댓글)
### 수정 전
- vue 적용 전 기본 listing만 가능한 기능은 있었으나, 필수 기능이 빠져있었습니다.
- 위의 기본적인 기능은 thymeleaf 및 js 로만 구현되어 있었습니다.

### 수정 후
- vue 적용
- 신고기능은 다음과 같습니다.
1) 기본적으로 신고 처리 기능은 영구정지, 일시정지, 신고취소가 있습니다.
2) 영구정지 시 9999일 일시정지 기능과 동일합니다.
3) 일시정지 시 관리자의 입력을 받도록 합니다. 입력값은 정지일수 입니다.
4) 신고 취소 시 신고는 처리상태가 되고, 일시정지 또는 영구정지로 수행되는 로직 (신고테이블의 blockedAt, releasedAt 및 멤버테이블의 isSuspended) 를 null 및 false로 설정합니다. 
5) 모임글 및 댓글 신고 취소 시, 모임글 또는 댓글의 삭제상태 (deletedAt) 을 null로 변경합니다.
6) 검색기능이 있는데, 검색기능은 사용자 신고 화면에서 기본적으로 사용자 닉네임, 모임글은 모임글 제목, 댓글은 댓글 내용으로 조회합니다.
7) 검색 시 날짜 선택 및 1회 검색 시 조회할 수 있는 검색 수를 설정할 수 있습니다.

![image](https://user-images.githubusercontent.com/102606939/214033479-656e7135-daa9-4f3c-a208-427e11ed2ae0.png)
<img width="940" alt="image" src="https://user-images.githubusercontent.com/102606939/214033527-c4be0ebd-4ecd-432d-922c-b23320508f9e.png">
![image](https://user-images.githubusercontent.com/102606939/214033567-9e1eb76d-cfaf-4abd-a74f-1643032566ac.png)
![image](https://user-images.githubusercontent.com/102606939/214033601-c533bfec-8325-4441-93e6-1393bf7aa8de.png)
![image](https://user-images.githubusercontent.com/102606939/214033675-c613609c-5ca5-4530-8c45-28604639e724.png)


## 💡 기타
- 아마 관리자 관련된 모든 PR이 합쳐지지 않으면 동작 안할 것 같습니다. 양해부탁드립니다. (별도 브렌치 만들어서 관리자 관련 브렌치 전부 머지하시면 보실 수 있긴 해요)
