### PR TITLE
[FEAT] 관리자 댓글 관리 기능 추가

### DIFF
--- a/src/main/java/com/zpop/web/controller/admin/CommentController.java
+++ b/src/main/java/com/zpop/web/controller/admin/CommentController.java
@@ -1,0 +1,60 @@
+package com.zpop.web.controller.admin;
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zpop.web.dto.admin.AdminCommentDto;
+import com.zpop.web.dto.admin.AdminCommentListResponse;
+import com.zpop.web.service.admin.AdminCommentService;
+
+@Controller("adminCommentController")
+@RequestMapping("api/admin/comment")
+@RestController
+public class CommentController {
+
+	private final AdminCommentService service;
+	
+	@Autowired
+	public CommentController (AdminCommentService adminCommentService) {
+		this.service = adminCommentService;
+	}
+	
+	@GetMapping("list")
+	public AdminCommentListResponse getList(
+		@RequestParam(name="page", defaultValue="1") int page
+		,@RequestParam @Nullable String keyword
+		,@RequestParam @Nullable Integer period
+		,@RequestParam @Nullable @DateTimeFormat(iso=ISO.DATE) Date minDate
+		,@RequestParam (name="option", defaultValue = "nickname") String option
+		,@RequestParam(name="num", defaultValue="10") Integer num
+		,@RequestParam(name="order", defaultValue="desc") String order) {
+		
+		List<AdminCommentDto> comments = service.getList(page, keyword, option, minDate, period, num, order);
+		int count = service.countBySearch(keyword, option, minDate, period);
+
+		return AdminCommentListResponse
+									.builder()  
+									.comments(comments)
+									.count(count)
+									.build();
+
+	}
+
+	@DeleteMapping()
+	public int updateDeletedAt(@RequestParam List<Integer> ids, @RequestParam boolean isDeleted){
+		
+		int result = service.updateDeleteAt(ids,isDeleted);
+		return result;
+	}
+}

--- a/src/main/java/com/zpop/web/dto/admin/AdminCommentDto.java
+++ b/src/main/java/com/zpop/web/dto/admin/AdminCommentDto.java
@@ -1,0 +1,36 @@
+
+package com.zpop.web.dto.admin;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminCommentDto {
+
+    private int meetingId;
+    private String meetingTitle;
+    private int id;
+    private String content;
+    private int writerId;
+    private int groupId;
+    private String nickname;
+    private int parentCommentId;
+    private int parantCommentWriterId;
+    private String parentCommentContent;
+    @JsonFormat(pattern ="yyyy-MM-dd HH 시 mm 분")
+    private Date createdAt;
+    @JsonFormat(pattern ="yyyy-MM-dd HH 시 mm 분")
+    private Date updatedAt;
+    @JsonFormat(pattern ="yyyy-MM-dd HH 시 mm 분")
+    private Date deletedAt;
+
+}

--- a/src/main/java/com/zpop/web/dto/admin/AdminCommentListResponse.java
+++ b/src/main/java/com/zpop/web/dto/admin/AdminCommentListResponse.java
@@ -1,0 +1,23 @@
+package com.zpop.web.dto.admin;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+public class AdminCommentListResponse {
+    
+    private List<AdminCommentDto> comments;
+    private int count;
+
+}

--- a/src/main/java/com/zpop/web/service/admin/AdminCommentService.java
+++ b/src/main/java/com/zpop/web/service/admin/AdminCommentService.java
@@ -1,0 +1,13 @@
+package com.zpop.web.service.admin;
+
+import java.util.Date;
+import java.util.List;
+
+import com.zpop.web.dto.admin.AdminCommentDto;
+
+public interface AdminCommentService {
+
+    List<AdminCommentDto> getList(int page, String keyword, String option, Date minDate, Integer period, Integer num, String order);
+    int countBySearch(String keyword, String option, Date minDate, Integer period);
+    int updateDeleteAt(List<Integer> ids, boolean isDeleted);
+}

--- a/src/main/java/com/zpop/web/service/admin/DefaultAdminCommentService.java
+++ b/src/main/java/com/zpop/web/service/admin/DefaultAdminCommentService.java
@@ -1,0 +1,42 @@
+package com.zpop.web.service.admin;
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.zpop.web.dao.CommentDao;
+import com.zpop.web.dto.admin.AdminCommentDto;
+
+@Service
+public class DefaultAdminCommentService implements AdminCommentService{
+
+    @Autowired
+    CommentDao dao;
+
+    @Override
+    public List<AdminCommentDto> getList(int page, String keyword, String option, Date minDate, Integer period, Integer num, String order){
+        int size = num;
+        int offset=(page-1)*size;
+        List<AdminCommentDto> result = dao.getAdminList(offset, size, keyword,option,minDate,period,order);
+
+        return result;
+    }
+    
+    public int countBySearch(String keyword, String option, Date minDate, Integer period){
+        return dao.countBySearch(keyword, option, minDate, period);
+    }
+
+    @Override
+    public int updateDeleteAt(List<Integer> ids, boolean isDeleted) {
+        int result = 0;
+        if (isDeleted){
+            result = dao.updateAllDeletedAt(ids);
+        }
+        else{
+            result = dao.removeAllDeletedAt(ids);
+        }
+        return result;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,8 @@ mybatis.type-aliases-package=com.zpop.web.entity, com.zpop.web.dto
 mybatis.mapper-locations=classpath*:mapper/*Mapper.xml
 logging.level.com.zpop.web.dao=trace
 spring.output.ansi.enabled=always
+
+#DB에 있는 데이터를 아래의 설정 없이 그냥 받아오면 UTC시간대로 표시됨 (현재시간 - 9 Hours)
+spring.jackson.time-zone=Asia/Seoul
+
 #server.error.include-stacktrace=never

--- a/src/main/vue/src/views/admin/comment/Comment.vue
+++ b/src/main/vue/src/views/admin/comment/Comment.vue
@@ -1,0 +1,40 @@
+<template>
+    <Category :categories="categories" :categoryStatus="categoryStatus"/>
+    <router-view/>
+</template>
+
+<script setup>
+import {ref, watch} from 'vue';
+import Category from '../../../components/admin/Category.vue';
+import { useRoute } from 'vue-router';
+const emit = defineEmits(["menuChanged"]);
+emit("menuChanged", "list");
+
+const categoryStatus = ref(0);
+const route = useRoute();
+const categories = [
+    {
+        name: '댓글 리스트',
+        link: 'list'
+    }, 
+];
+
+watch(route, () => changeCategory(route.path.split('/')[3]));
+
+const changeCategory = (category) => {
+    let value;
+    switch(category){
+        case "list":
+        value = 0;
+        break;
+    }
+    categoryStatus.value = value;
+}
+
+changeCategory(route.path.split('/')[3]);
+
+</script>
+
+<style>
+
+</style>

--- a/src/main/vue/src/views/admin/comment/List.vue
+++ b/src/main/vue/src/views/admin/comment/List.vue
@@ -1,0 +1,266 @@
+<template>
+    <search-bar :searchOption="true"/>
+    <admin-table @search="searchHandler" :isLoaded="listData.isLoaded">
+        <template #left-buttons>
+            <input @click="checkAllHandler" class="checkbox" type="checkbox" name="table-checkbox"/>
+            <span @click="deleteAllComments" class="table-bar__icon table-bar__icon-check"></span>
+            <span @click="cancelDeleteAllComments" class="table-bar__icon table-bar__icon-x"></span>
+        </template>
+        <template #right-buttons>
+            <span class="table-bar__page"> {{`${listData.count.toLocaleString()} 개 중 ` + getMinMaxIndex }} </span>
+            <span @click="decreasePage" class="table-bar__icon table-bar__icon-arrow-left hide"></span>
+            <span @click="increasePage" class="table-bar__icon table-bar__icon-arrow-right hide"></span>
+        </template>
+        <template #list-header>
+            <ul>
+                <li><span>ID</span>
+                    <button>
+                        <img src="/images/icon/up-down.svg" alt="">
+                    </button>
+                </li>
+                <li class="admin-tb-3">모임글 제목/댓글 내용</li>
+                <li class="admin-tb-2">작성자(id)</li>
+                <li class="admin-tb-1">부모 댓글 id</li>
+                <li class="admin-tb-2">작성 일자</li>
+                <li class="admin-tb-1">삭제여부</li>
+            </ul>
+        </template>
+        <template #list-content>
+            <li v-for="(item, index) in listData.comments" :key="index" class="table-list__content">
+                <ul class="list-content">
+                    <li class="list-content__id">
+                        <input type="checkbox" class="checkbox" v-model="isChecked[index]">
+                        <span>{{ item.id }}</span>
+                    </li>
+                    <li class="list-content__title admin-tb-3">
+                        <span class="bold">{{ item.meetingTitle}}</span>
+                        <span>{{ item.content}}</span>
+                    </li>
+                    <li class="admin-tb-2">{{ `${item.nickname}(${item.writerId})` }}</li>
+                    <li class="admin-tb-1">{{ `${item.parentCommentId==0?'N/A':item.parentCommentId}` }}</li>
+                    <li class="list-content_date admin-tb-2">{{ item.createdAt }}</li>
+                    <li class="list-content__status admin-tb-1">
+                        <span class="status status--round" :class="item.deletedAt ? 'status--negative' : 'status--incomplete'">
+                            {{(item.deletedAt) ? 'TRUE' : 'FALSE'}}
+                        </span>
+                    </li>
+                </ul>
+            </li>
+        </template>
+    </admin-table>
+</template>
+
+<script setup>
+import SearchBar from '../../../components/admin/SearchBar.vue';
+import AdminTable from '../../../components/admin/Table.vue';
+import { computed, reactive, ref, watch } from 'vue';
+import router from '../../../router'
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+
+
+const listData = reactive({
+    comments: [],
+    count: 0,
+    isLoaded: false,
+});
+const searchOption = reactive({
+    keyword: String,
+    option: String,
+    page: Number,
+    num: Number,
+    minDate: String,
+    period: Number,
+    order: String,
+})
+
+const reverseOrder = () => {
+    if (searchOption.order == "desc") {
+        searchOption.order = "asc";
+    }
+    else {
+        searchOption.order = "desc";
+    }
+    updateUrl();
+}
+
+const updateOption = () => {
+    let { keyword, option, page = 1, num = 10, minDate = new Date().toISOString().slice(0, 10),
+        period = 9999, order = "desc" } = route.query;
+
+    searchOption.keyword = keyword;
+    searchOption.option = option;
+    searchOption.page = page;
+    searchOption.num = num;
+    searchOption.minDate = minDate;
+    searchOption.period = period;
+    searchOption.order = order;
+}
+updateOption();
+
+const isChecked = reactive([]);
+
+const checkAllHandler = (event) => {
+    let allCheckboxChecked = event.target.checked;
+
+    for (let index in isChecked) {
+        isChecked[index] = allCheckboxChecked;
+    }
+}
+
+const pageMinIndex = () => {
+    const pageMaxNum = (searchOption.page - 1) * searchOption.num + 1;
+    return (pageMaxNum <= listData.count ? pageMaxNum : listData.count);
+}
+
+const pageMaxIndex = () => {
+    const pageMaxNum = (searchOption.page * searchOption.num);
+    return (pageMaxNum <= listData.count ? pageMaxNum : listData.count);
+}
+
+const getMinMaxIndex = computed(() => {
+    return `${pageMinIndex().toLocaleString()}-${pageMaxIndex().toLocaleString()}`
+})
+
+const decreasePage = () => {
+    if (pageMinIndex() == 0 || pageMinIndex() == 1) {
+        return;
+    }
+
+    if (!listData.isLoaded) {
+        return;
+    }
+    searchOption.page--;
+    listData.isLoaded = false;
+    updateUrl();
+}
+
+const increasePage = () => {
+    if (pageMaxIndex() == listData.count) {
+        return;
+    }
+    if (!listData.isLoaded) {
+        return;
+    }
+    searchOption.page++;
+    listData.isLoaded = false;
+    updateUrl();
+}
+
+const closeDetailModal = () => {
+    meetingDetails.isLoaded = false;
+}
+
+const updateUrl = () => {
+    router.push({
+        path: route.path,
+        query: searchOption,
+    });
+}
+
+watch(route, () => {
+    updateOption();
+    requestData();
+})
+
+const requestData = () => {
+    listData.isLoaded = false;
+    //배열초기화
+    isChecked.length = 0;
+
+    fetch(`/api/admin/comment/list${window.location.search}`)
+        .then(res => res.json())
+        .then(data => {
+            listData.comments = [];
+            listData.count = data.count;
+            data.comments.forEach(item => {
+                listData.comments.push(item)
+                isChecked.push(false);
+            });
+            listData.isLoaded = true;
+        })
+}
+requestData();
+
+const deleteAllComments = () => {
+    let ids = [];
+    for (let index in isChecked){
+        if (isChecked[index]){
+            ids.push(listData.comments[index].id);
+        }
+    }
+
+    if (ids.length == 0) {
+        alert('선택한 댓글이 없습니다.');
+        return;
+    }
+
+    if (!confirm(`정말로 다음 댓글을 삭제하시겠습니까?\n댓글번호: ${ids}`)) return
+    const url = `/api/admin/comment?ids=${ids}`
+    const formData = new FormData();
+    formData.append('isDeleted', true);
+    const option = {
+        method: 'DELETE',
+        body: formData,
+    }
+    fetch(url, option)
+    .then(res => {
+        if (res.ok) {
+            alert('댓글 삭제가 정상적으로 처리되었습니다.')
+            requestData();
+        }
+        else {
+            throw new Error();
+        }
+    })
+    .catch(err => {
+        alert('댓글 삭제 과정에서 오류가 발생하였습니다');
+    })
+}
+
+const cancelDeleteAllComments = () => {
+    let ids = [];
+    for (let index in isChecked){
+        if (isChecked[index]){
+            ids.push(listData.comments[index].id);
+        }
+    }
+
+    if (ids.length == 0) {
+        alert('선택한 댓글이 없습니다.');
+        return;
+    }
+
+    if (!confirm(`정말로 다음 댓글을 삭제 취소하시겠습니까?\n댓글번호: ${ids}`)) return
+    const url = `/api/admin/comment?ids=${ids}`
+    const formData = new FormData();
+    formData.append('isDeleted', false);
+    const option = {
+        method: 'DELETE',
+        body: formData,
+    }
+    fetch(url, option)
+    .then(res => {
+        if (res.ok) {
+            alert('댓글 삭제 취소가 정상적으로 처리되었습니다.')
+            requestData();
+        }
+        else {
+            throw new Error();
+        }
+    })
+    .catch(err => {
+        alert('댓글 삭제 취소 과정에서 오류가 발생하였습니다');
+    })
+}
+
+
+
+</script>
+
+<style scoped>
+.list-content__title{
+    flex-direction: column;
+}
+</style>


### PR DESCRIPTION
## 🛠 작업사항
- 댓글관리 기능을 추가하였습니다.
### 수정 전
- 기존에는 댓글조회 및 관리기능이 없었습니다.

### 수정 후
- 댓글을 삭제하거나, 삭제를 취소할 수 있습니다.
- 댓글 내용을 검색하거나, 검색결과를 옵션을 통해 조절할 수 있습니다.

## 💡 기타
- 댓글 상세내용 조회 기능이 추후 구현되어야 할 것 같습니다.

