### PR TITLE
[FIX] 모임글 등록 시 입력값이 유효하지 않은 경우에도 정상 처리되는 모달로 전환되는 이슈 해결

### DIFF
--- a/src/main/vue/src/utils/RegisterForm.js
+++ b/src/main/vue/src/utils/RegisterForm.js
@@ -167,6 +167,7 @@ export class RegisterForm{
 
     closeStatusModal(){
         this.modalState.isOpened = false;
+        this.modalState.sectionNum = 1;
     }
 
     openStatusModal(){
@@ -177,14 +178,22 @@ export class RegisterForm{
         this.openStatusModal();
         const request = api.meeting.postRequest(this.getJSONData());
         request
-        .then(res => res.json())
+        .then(res => {
+            if (res.status === 400){
+                throw new Error('오류: 입력값을 확인해주세요');
+            }
+            if (res.status === 500){
+                throw new Error('서버에 오류가 발생했습니다.');
+            }
+            return res.json();
+        })
         .then(data => {
             this.modalState.sectionNum = 2;
             this.meetingUrl = `/meeting/${data.meetingId}`
         })
         .catch(err=>{
             this.modalState.sectionNum = 0;
-            this.errorMessage = err;
+            this.errorMessage = err.message;
         })
     }
     setContentInEditor(){

--- a/src/main/vue/src/views/meeting/Register.vue
+++ b/src/main/vue/src/views/meeting/Register.vue
@@ -49,7 +49,7 @@
                             <div class="icon-cancel"></div>
                             <div class="register-status__text">
                                 <div class="register-status__message">게시글 등록에 실패했어요.<br>다음 내용을 확인해주세요.</div>
-                                <div class="register-status__message">registerForm.errorMessage</div>
+                                <div class="register-status__message">{{registerForm.errorMessage}}</div>
                             </div>
                         </div>
                         <div class="modal__content">


### PR DESCRIPTION
## 🛠 작업사항
- 모임글 등록 시 입력값이 유효하지 않은 경우에도 정상 처리되는 모달로 전환되었는데, 해당 이슈를 해결하였음
### 수정 전
<img width="449" alt="image" src="https://user-images.githubusercontent.com/102606939/214093406-164fc7b2-7c13-4955-a660-a52b500c203c.png">
입력값 검증 후 유효하지 않은 입력값이 확인되었으나, 정상 처리되는 모달로 전환되었음
### 수정 후
<img width="502" alt="image" src="https://user-images.githubusercontent.com/102606939/214093791-a16f5989-d4fc-4348-9803-4066bd044599.png">
입력값 검증 후 유효하지 않은 입력값이 확인되면 오류 모달을 띄우도록 수정함


## 💡 기타
- N/A
