### PR TITLE
[FIX] 메인 조회화면에서 지역옵션 선택 시 3개 이상 고르는 경우 무조건 마지막 지역이 없어지는 버그 수정

### DIFF
--- a/src/main/vue/src/components/meeting/option-control/Region.vue
+++ b/src/main/vue/src/components/meeting/option-control/Region.vue
@@ -42,26 +42,23 @@ const selectBoxClickedHandler = () => {
 
 const optionClickedHandler = (optionId, name, dataId) => {
     option.isOpened = !option.isOpened;
-    console.log('옵션클릭')
     const index = getIndexOfSelectedRegion(dataId);
     
+    // 기존에 이미 선택한 지역이라면 제거
     if (index != -1){
         selectedRegions.splice(index,1);
     }
     
+    // 지역을 이미 3개 선택한 상태라면, 가장 마지막 것을 제거하고, 선택된 것을 마지막에 추가
     else if (selectedRegions.length >= 3){
         selectedRegions.pop();
+        selectedRegions.push({ id : dataId, name: name });
     }
     else{
-        selectedRegions.push(
-            {
-                id : dataId,
-                name: name,
-            }
-        )
+        selectedRegions.push({ id : dataId, name: name })
     }
+    
     updateRegions();
-    return;
 }
 
 const getIndexOfSelectedRegion = (dataId) => {


### PR DESCRIPTION
## 🛠 작업사항
- 메인화면에서 지역옵션 선택 시 3개 이상 선택하는 경우 가장 마지막에 선택한 값이 무조건 사라지는 버그 수정함
### 수정 전
- 조건문에서 지역옵션이 3개인 경우 마지막으로 선택된 지역옵션을 제거해버리고 선택된 지역옵션을 추가하는 로직을 넣지 않았음
### 수정 후
- 상기 로직을 추가하였음
## 💡 기타
- N/A