### PR TITLE
[FEAT, REFACTOR] 로그인 기능 개선 및 카카오 로그인 기능 수정

### DIFF
--- a/src/main/vue/src/components/modal/LoginModal.vue
+++ b/src/main/vue/src/components/modal/LoginModal.vue
@@ -10,7 +10,7 @@
                 </div>
                 <div class="login-btn-container">
                     <a class="login-btn login-btn--kakao text-hidden" id="kakao-login-btn"
-                        href="javascript:Kakao.Auth.authorize({redirectUri: 'http://localhost:5173/login/oauth/kakao'})">카카오
+                        href="javascript:Kakao.Auth.authorize({redirectUri: 'http://localhost:5173?login=kakao'})">카카오
                         로그인 버튼</a>
                     <a @click="onNaverLoginClick" class="login-btn login-btn--naver text-hidden" id="naver-login-btn"
                         href="javascript:void(0)">네이버
@@ -44,7 +44,7 @@ const generateRandomString = (num) => {
 
 const serviceURL = "https://nid.naver.com/oauth2.0/authorize";
 const clientId = "fXPYssaX_SOB2qThvRtF";
-const redirectUrl = encodeURI("http://localhost:5173/login/oauth/naver");
+const redirectUrl = encodeURI("http://localhost:5173?login=naver");
 const responseType = "code";
 const state = encodeURI(generateRandomString(10));
 const requestUrl = `${serviceURL}?response_type=${responseType}&client_id=${clientId}&state=${state}&redirect_uri=${redirectUrl}`;

--- a/src/main/vue/src/router/index.js
+++ b/src/main/vue/src/router/index.js
@@ -16,15 +16,15 @@ async function isAuth (to, from) {
   }
 }
 
-function redirectRouteAfterLogin(to, from) {
-  // 로컬 스토리이제 저장된 리다이렉트 라우트가 있다면,
-  // 로그인 성공 후 해당 라우트로 이동한다.
-  const redirectRoute = localStorage.getItem("redirect-route");
-  if (from.path.includes("login/oauth") && redirectRoute) {
-    localStorage.removeItem("redirect-route");
-    router.push(redirectRoute);
-  }
-}
+// function redirectRouteAfterLogin(to, from) {
+//   // 로컬 스토리이제 저장된 리다이렉트 라우트가 있다면,
+//   // 로그인 성공 후 해당 라우트로 이동한다.
+//   const redirectRoute = localStorage.getItem("redirect-route");
+//   if (from.path.includes("?login=") && redirectRoute) {
+//     localStorage.removeItem("redirect-route");
+//     router.push(redirectRoute);
+//   }
+// }
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -38,10 +38,10 @@ const router = createRouter({
           path: "/:pathMatch(.*)",
           component: () => import("@/views/404.vue"),
         },
-        {
-          path: "login/oauth/:pathMatch(.*)*",
-          component: () => import("@/views/LoginProc.vue"),
-        },
+        // {
+        //   path: "login/oauth/:pathMatch(.*)*",
+        //   component: () => import("@/views/LoginProc.vue"),
+        // },
         {
           path: "meeting",
           children: [
@@ -50,7 +50,7 @@ const router = createRouter({
               name: "meetingList",
               component: () => import("@/views/meeting/List.vue"),
               alias: "/",
-              beforeEnter: [redirectRouteAfterLogin],
+              // beforeEnter: [redirectRouteAfterLogin],
             },
             {
               path: "search",

--- a/src/main/vue/src/views/LoginProc.vue
+++ b/src/main/vue/src/views/LoginProc.vue
@@ -1,5 +1,5 @@
 <template>
-    <Modal>
+    <Modal v-if="route.query.login">
         <template #modal-body>
             <div>
                 <div class="modal__content-container">
@@ -27,20 +27,39 @@ const memberStore = useMemberStore();
 
 const route = useRoute();
 const router = useRouter();
-const oauthLoginUrl = '/api' + route.fullPath;
 
-fetch(oauthLoginUrl)
+const requestOAuth = () => {
+    const oauthLoginUrl = `/api/login/oauth/${route.query.login}?code=${route.query.code}&state=${route.query.state}`;
+
+    fetch(oauthLoginUrl)
     .then(res => res.json())
     .then(data => {
         console.log("성공 : fetch oauthLoginUrl ")
         memberStore.setInfo(data);
-        router.push("/");
+
+        // router에 있던 리다이렉트 기능이 이쪽으로 옮겨짐
+        // 동일 view에서는 push를 해도 beforeEnter기능이 동작하지 않음
+        // 예를 들면 '/login?naver...' 에서 '/'로 push해도 beforeEneter는 활성화되지 않음
+        const redirectRoute = localStorage.getItem("redirect-route");
+        if (redirectRoute) {
+            localStorage.removeItem("redirect-route");
+            router.push(redirectRoute);
+        }
+        else{
+            router.push({path: '/'});
+        }
     })
     .catch((err) => {
         console.info("Login.vue err", err)
         alert("로그인에 오류가 발생했음");
-        router.push("/");
+        router.push({path: '/'});
     });
+}
+
+if (route.query.login){
+    requestOAuth();
+}
+
 
 </script>
 

--- a/src/main/vue/src/views/meeting/List.vue
+++ b/src/main/vue/src/views/meeting/List.vue
@@ -10,6 +10,7 @@ import SearchBar from "@/components/meeting/option-control/SearchBar.vue";
 import ModalDefault from "@/components/modal/Default.vue";
 import Banner from "../../components/meeting/Banner.vue"
 import { ServerException } from "@/utils/ServerException";
+import LoginProc from "../LoginProc.vue";
 
 const emit = defineEmits(["throw"]);
 
@@ -166,6 +167,7 @@ function closeRequiredKeywordModal() {
       <LoadingRoller :isShow="state.loadingOn" />
     </div>
   </div>
+  <login-proc/>
 </template>
 
 <style scoped>


### PR DESCRIPTION
## 🛠 작업사항
- 로그인 기능을 개선했습니다
- 카카오 로그인 기능을 다시 추가했습니다.
### 수정 전
- 기존에는 소셜로그인 리다이렉트 url이 아래와 같이 별도의 view로 있었는데, view 디자인이 따로 있는 것도 아니고 해서 그냥 메인 화면에 통합하는 것이 어떨까 의견드립니다.
![image](https://user-images.githubusercontent.com/102606939/214098278-6c2a1c56-a323-4794-aea8-ab8b96bc260c.png)

- redirect url 이 수정이 안돼서 카카오 로그인이 안된 것 같습니다.
### 수정 후
- loginProc.vue는 별도의 router-view가 아닌 메인화면의 component로 이동했습니다.
- 옮기고 나니 기존에 사용했던 /login/oauth/naver(또는 kakao)는 사용할 수 없어서 redirect url을 변경했습니다.
=> /?login=naver 나 /?login=kakao 로 redirect 하고자 합니다.
- 동일 router-view 내에서 push하는 것은 router.push 시 router guard의 beforeEnter 가 활성화되지 않는 것 같습니다. 따라서 router에 있던 redirectRouteAfterLogin 는 loginProc 기능의 일부로 옮겼습니다.
=> 로직을 그쪽으로 옮겨도 리다이렉트 기능은 잘 동작합니다.

![image](https://user-images.githubusercontent.com/102606939/214098978-ff9035b3-286e-45cf-89ae-abc3013c469e.png)

수정 전
```js
function redirectRouteAfterLogin(to, from) {
  const redirectRoute = localStorage.getItem("redirect-route");
  if (from.path.includes("login/oauth") && redirectRoute) {
    localStorage.removeItem("redirect-route");
    router.push(redirectRoute);
  }
}
```

수정 후 
```js
fetch(oauthLoginUrl)
    .then(res => res.json())
    .then(data => {
        console.log("성공 : fetch oauthLoginUrl ")
        memberStore.setInfo(data);

        // router에 있던 리다이렉트 기능이 이쪽으로 옮겨짐
        // 동일 view에서는 push를 해도 beforeEnter기능이 동작하지 않음
        // 예를 들면 '/login?naver...' 에서 '/'로 push해도 beforeEneter는 활성화되지 않음
        const redirectRoute = localStorage.getItem("redirect-route");
        if (redirectRoute) {
            localStorage.removeItem("redirect-route");
            router.push(redirectRoute);
        }
        else{
            router.push({path: '/'});
        }
    })
```

## 💡 기타
- merge되면 이제 api.properties의 redirect URI를 다음과 같이 변경해야 합니다.

```.properties
KAKAO_REDIRECT_URI=http://localhost:5173?login=kakao
NAVER_REDIRECT_URI=http://localhost:5173?login=naver
```

