### PR TITLE
[FEAT] 모임글 상세보기에서 사용되는 select modal 추가

### DIFF
--- a/src/main/vue/src/assets/css/meeting/component/select.css
+++ b/src/main/vue/src/assets/css/meeting/component/select.css
@@ -114,8 +114,13 @@
   border-radius: 5px;
   box-shadow: 0px 5px 15px 0px #00000033;
   cursor: none;
+  position:absolute;
+  top:30px;
+  right:0px;
+  background-color: var(--white);
 }
-.modal-select__contents {
+
+.modal-select__contents{
   display: flex;
   height: 100%;
   width: 100%;
@@ -127,13 +132,15 @@
   align-items: center;
   justify-content: space-between;
   cursor: pointer;
-}
-
-.modal-select .icon {
-  display: flex;
-  margin-right: 15px;
-}
-
-.modal-select :last-child {
-  color: var(--red-theme);
-}
+  
+  }
+  
+  .modal-select .icon{
+    display: flex;
+    margin-right: 15px;
+  }
+  
+  .modal-select__contents--report
+  ,.modal-select__contents--delete{
+    color:var(--red-theme);
+  }

--- a/src/main/vue/src/components/comment/Comment.vue
+++ b/src/main/vue/src/components/comment/Comment.vue
@@ -4,6 +4,7 @@
   import { defineProps } from 'vue';
   import { useCommentStore} from '@/stores/commentStore'
   import InputBox from './InputBox.vue';
+  import SelectModal from './SelectModal.vue';
 
   const props = defineProps({
     comment:Object
@@ -68,6 +69,14 @@
     replyCnt.value = !replyCnt.value;     //카운트 비노출
 
   }
+
+  const isModalClosed = ref(true); // 모달 상태 정의
+
+  // select modal 열고 닫기
+  function closeSelectModal(){
+    isModalClosed.value = !isModalClosed.value;
+  }
+
 </script>
 
 <template>
@@ -75,14 +84,11 @@
     <span class="profile__image"></span>
     <span class="profile__nickname">{{ comment.nickname }}</span>
     <span class="profile__time">{{comment.elapsedTime}}</span>
-    <button></button>
-    <th:block th:if="${comment.isMyComment}">
-            <div sec:authorize="isAuthenticated()" th:replace="~{inc/meeting-detail-modal::writer}"></div>
-    </th:block>
-    <th:block th:if="${!comment.isMyComment}">
-            <div sec:authorize="isAuthenticated()" th:replace="~{inc/meeting-detail-modal::reader}"></div>
-    </th:block>
-        </div>
+    <button @click="closeSelectModal">
+      <!-- role에 writer를 부여하면 작성자 기준으로 모달이 나오고, member를 부여하면 일반 로그인 사용자 모달이 나온다. -->
+      <SelectModal :role="'writer'" v-if="!isModalClosed"/>
+    </button>  
+  </div>
   <span class="comment__content">{{ comment.content }}</span>
   <div class="comment__replies" :class="{ hidden:hasBox }">
     <span class="pointer underline reply-cnt"  @click="toggleReplyCnt"  v-if="hasReply(comment)" v-show="replyCnt" >답글 {{ countOfReply }}개</span>
@@ -105,5 +111,9 @@
  .no-margin{
   margin: 0;
   padding: 0;
+}
+
+.profile > button{
+  position:relative;
 }
 </style>

--- a/src/main/vue/src/components/comment/SelectModal.vue
+++ b/src/main/vue/src/components/comment/SelectModal.vue
@@ -1,0 +1,33 @@
+<template>
+    <!-- 💚 댓글 (작성자)-->
+    <div v-if="role==='writer'" class="modal-select select-box__options">
+        <div class="modal-select__contents" data-id="comment-edit">수정
+            <span class="icon icon-edit"></span>
+        </div>
+        <div class="modal-select__contents modal-select__contents--delete" data-id="comment-delete">삭제
+            <span class="icon icon-trash"></span>
+        </div>
+    </div>
+
+    <!-- 💚 댓글 (기본유저)-->
+    <div v-if="role==='member'" class="modal-select select-box__options">
+
+        <div class="modal-select__contents mocal-select__contents--report" data-id="comment-report">
+            댓글 신고
+            <span class="icon icon-siren-red"></span>
+        </div>
+    </div>
+    <!--------------------------  케밥 모달 추가 --------------------------->
+</template>
+
+<script setup>
+const props = defineProps(['role']);
+
+</script>
+
+<style scoped>
+.select-box__options{
+    max-height:max-content;
+    overflow: visible;
+}
+</style>

--- a/src/main/vue/src/components/meeting/article/Article.vue
+++ b/src/main/vue/src/components/meeting/article/Article.vue
@@ -6,7 +6,10 @@
       </div>
       <div class="title-container">
         <h2 class="title">{{ meetingDetailStore.title }}</h2>
-        <span class="kebab icon icon-kebab"></span>
+        <span @click="closeSelectModal" class="kebab icon icon-kebab">
+          <!-- role에 writer를 바인딩하면 작성자 기준 모달, participant를 바인딩하면 참여자 기준 모달, member를 바인딩하면 일반 로그인 사용자 모달이 나온다. -->
+          <SelectModal :role="'participant'" v-if="!isSelectModalClosed"/>
+        </span>
         <img src="" alt="" />
       </div>
 
@@ -80,10 +83,17 @@ import { useMeetingDetailStore } from "@/stores/meetingDetailStore";
 import Round from "@/components/button/Round.vue";
 import RoundDisabled from "@/components/button/RoundDisabled.vue";
 import ControlModal from "./ControlModal.vue";
+import SelectModal from "./SelectModal.vue";
 
 const memberStore = useMemberStore();
 const loginModalStore = useLoginModalStore();
 const meetingDetailStore = useMeetingDetailStore();
+
+const isSelectModalClosed = ref(true);
+
+function closeSelectModal() {
+  isSelectModalClosed.value = !isSelectModalClosed.value;
+}
 
 // 참여, 마감, 참여취소, 링크 모달 on/off
 let controlModalOn = ref(false);
@@ -130,4 +140,13 @@ async function onClickCloseBtn() {
 
 <style>
 @import url(@/assets/css/meeting/article.css);
+
+.title-container .kebab{
+  position:relative;
+}
+
+.title-container .icon{
+  overflow: visible;
+  text-indent: 0px;
+}
 </style>

--- a/src/main/vue/src/components/meeting/article/SelectModal.vue
+++ b/src/main/vue/src/components/meeting/article/SelectModal.vue
@@ -1,0 +1,43 @@
+<template>
+    <!-- 작성자 -->
+    <div class="modal-select" v-if="role === 'writer'">
+        <div class="modal-select__contents">복사 하기
+            <span class="icon icon-copy"></span>
+        </div>
+        <div class="modal-select__contents">수정
+            <span class="icon icon-edit"></span>
+        </div>
+        <div class="modal-select__contents modal-select__contents--delete">삭제
+            <span class="icon icon-trash"></span>
+        </div>
+    </div>
+    <!-- 참여자 -->
+    <div class="modal-select" v-if="role === 'participant'" id="meeting__article-tool">
+        <div class="modal-select__contents">복사하기
+            <span class="icon icon-copy"></span>
+        </div>
+        <div class="modal-select__contents">참여링크
+            <span class="icon icon-link"></span>
+        </div>
+        <div class="modal-select__contents modal-select__contents--report">글 신고
+            <span class="icon icon-siren-red"></span>
+        </div>
+    </div>
+    <!-- 기본 유저 -->
+    <div class="modal-select" v-if="role === 'member'" id="meeting__article-tool">
+        <div class="modal-select__contents">복사 하기
+            <span class="icon icon-copy"></span>
+        </div>
+        <div class="modal-select__contents modal-select__contents--report">글 신고
+            <span class="icon icon-siren-red"></span>
+        </div>
+    </div>
+</template>
+
+<script setup>
+const props = defineProps(['role']);
+
+</script>
+
+<style>
+</style>


### PR DESCRIPTION
## 🛠 작업사항
- 모임글 상세보기 시 사용되는 셀렉트 모달을 컴포넌트화 하고, 모임글, 댓글에 사용할 수 있도록 코드를 추가했습니다 
(실제 클릭 시 구현되는 내용 및 사용자의 role 을 확인하는 로직은 구현 X)

### 작업 상세 내용
- 케밥버튼 클릭 시 셀렉트 모달이 열리고 닫힙니다.
- 모임글 및 댓글의 케밥버튼을 클릭했을 때 발생되는 항목들을 변경하기 위해서는 해당 component에 바인딩되는 'role' 이라는 prop을 바꿔줘야합니다.
- 모임글의 경우 'writer', 'participant', 'member가 있으며 각각 모임글 작성자, 모임 참여자, 일반사용자에 해당하는 모임글 셀렉트 모달을 보여줍니다.
- 댓글의 경우 'writer', 'member' 두 종류가 있으며, 각각 댓글작성자, 일반사용자에 해당하는 댓글 셀렉트 모달을 보여줍니다.
## 💡 기타
- N/A
