### PR TITLE
[FIX] 모임글 상세보기의 Article.vue 에서 케밥 아이콘 클릭했을 때 css가 깨지는 현상 및 기타 CSS 수정

### DIFF
--- a/src/main/vue/src/assets/css/component/select.css
+++ b/src/main/vue/src/assets/css/component/select.css
@@ -5,7 +5,6 @@
   font-size: 16px;
   color: var(--dark-grey2);
   font-weight: var(--regular);
-  margin-top:8px;
 }
 
 .select-box--input * {

--- a/src/main/vue/src/components/header/Profile.vue
+++ b/src/main/vue/src/components/header/Profile.vue
@@ -46,4 +46,13 @@ const onLogoutClick = () => {
 .select-box::before{
     display:none;
 }
+.header__profile > button{
+    height:32px;
+}
+
+@media (min-width: 576px) {
+    .header__profile > button{
+    height:40px;
+}
+}
 </style>

--- a/src/main/vue/src/components/meeting/MeetingFormSelectInput.vue
+++ b/src/main/vue/src/components/meeting/MeetingFormSelectInput.vue
@@ -31,8 +31,8 @@ export default {
 </script>
 
 <style scoped>
-.error{
-    
+.input__label{
+    margin-bottom: 8px;
 }
 /* 
 .meeting-form__input{

--- a/src/main/vue/src/components/meeting/MeetingFormSelectTextInput.vue
+++ b/src/main/vue/src/components/meeting/MeetingFormSelectTextInput.vue
@@ -45,4 +45,7 @@ export default {
 .input-text__content-wrapper{
     margin-top:0;
 }
+.input__label{
+    margin-bottom: 8px;
+}
 </style>

--- a/src/main/vue/src/components/meeting/article/SelectModal.vue
+++ b/src/main/vue/src/components/meeting/article/SelectModal.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- 작성자 -->
-    <div class="modal-select" v-if="role === 'writer'">
+    <div class="modal-select select-box__options" v-if="role === 'writer'">
         <div class="modal-select__contents">복사 하기
             <span class="icon icon-copy"></span>
         </div>
@@ -12,7 +12,7 @@
         </div>
     </div>
     <!-- 참여자 -->
-    <div class="modal-select" v-if="role === 'participant'" id="meeting__article-tool">
+    <div class="modal-select select-box__options" v-if="role === 'participant'" id="meeting__article-tool">
         <div class="modal-select__contents">복사하기
             <span class="icon icon-copy"></span>
         </div>
@@ -24,7 +24,7 @@
         </div>
     </div>
     <!-- 기본 유저 -->
-    <div class="modal-select" v-if="role === 'member'" id="meeting__article-tool">
+    <div class="modal-select select-box__options" v-if="role === 'member'" id="meeting__article-tool">
         <div class="modal-select__contents">복사 하기
             <span class="icon icon-copy"></span>
         </div>
@@ -39,5 +39,8 @@ const props = defineProps(['role']);
 
 </script>
 
-<style>
+<style scoped>
+.modal-select{
+    right:20px;
+}
 </style>


### PR DESCRIPTION
## 🛠 작업사항
- css 수정하면서 케밥 셀렉트 모달의 css 버그가 발생했음
- select box의 css로 인해 헤더 프로필 버튼에 margin-top이 적용되었음
- 헤더 프로필 버튼의 크기가 이미지 height보다 살작 더 커서 정렬이 맞지 않는 현상이 있었음

### 수정 전
![image](https://user-images.githubusercontent.com/102606939/214319882-c3d2d29a-4c53-4287-bdd3-114ceb14a5ea.png)

![image](https://user-images.githubusercontent.com/102606939/214323735-5916c84e-aedc-4714-88e3-0e5e7f31e69d.png)


### 수정 후
![image](https://user-images.githubusercontent.com/102606939/214319809-2d2e3271-7842-442f-b579-fc586af96580.png)
- class 추가 및 scoped style 적용



![image](https://user-images.githubusercontent.com/102606939/214323616-d663ef21-0b79-4c76-9024-f5930a328c43.png)

-select box에 적용된 margin-top을 제거하고, 개별 component (모임글 관련 컴포넌트) 에서 scoped style로 적용하도록 변경
-프로필 버튼의 height 크기 설정 (반응형 고려하여 32px => 40px로 설정)

## 💡 기타
- N/A
