### PR TITLE
[FEAT] 최초 소셜로그인 시 사용자 닉네임 등록기능

### DIFF
--- a/src/main/java/com/zpop/web/controller/LoginController.java
+++ b/src/main/java/com/zpop/web/controller/LoginController.java
@@ -91,8 +91,7 @@ public class LoginController {
 		if (member == null) {
 			session.setAttribute("socialId", socialId);
 			session.setAttribute("loginType", loginType);
-			result.put("code", "success");
-			result.put("redirectUrl", "/register");
+			result.put("code", "REGISTER_REQUIRED");
 			return ResponseEntity.ok(result);
 		}
 		

--- a/src/main/java/com/zpop/web/entity/Member.java
+++ b/src/main/java/com/zpop/web/entity/Member.java
@@ -2,6 +2,19 @@ package com.zpop.web.entity;
 
 import java.util.Date;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
 public class Member {
     private int id;
     private int socialTypeId;
@@ -12,93 +25,5 @@ public class Member {
     private Date createdAt;
     private Date updatedAt;
     private Date resignedAt;
-
-    private boolean isSuspended;
-
-    public Member() {
-    }
-
-
-
-    public int getId() {
-        return this.id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public int getSocialTypeId() {
-        return this.socialTypeId;
-    }
-
-    public void setSocialTypeId(int socialTypeId) {
-        this.socialTypeId = socialTypeId;
-    }
-
-    public String getSocialId() {
-        return this.socialId;
-    }
-
-    public void setSocialId(String socialId) {
-        this.socialId = socialId;
-    }
-
-    public String getNickname() {
-        return this.nickname;
-    }
-
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public int getFame() {
-        return this.fame;
-    }
-
-    public void setFame(int fame) {
-        this.fame = fame;
-    }
-
-    public String getProfileImagePath() {
-        return this.profileImagePath;
-    }
-
-    public void setProfileImagePath(String profileImagePath) {
-        this.profileImagePath = profileImagePath;
-    }
-
-    public Date getCreatedAt() {
-        return this.createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return this.updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public Date getResignedAt() {
-        return this.resignedAt;
-    }
-
-    public void setResignedAt(Date resignedAt) {
-        this.resignedAt = resignedAt;
-    }
-
-    public boolean getIsSuspended() {
-        return this.isSuspended;
-    }
-
-    public void setIsSuspended(boolean isSuspended) {
-  
-        this.isSuspended = isSuspended;
-    }
 
 }

--- a/src/main/java/com/zpop/web/entity/NicknameLog.java
+++ b/src/main/java/com/zpop/web/entity/NicknameLog.java
@@ -1,7 +1,20 @@
 package com.zpop.web.entity;
 
-import java.sql.Date;
+import java.util.Date;
 
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
 public class NicknameLog {
     private int id;
     private int memberId;
@@ -12,37 +25,4 @@ public class NicknameLog {
         this.memberId = memberId;
         this.nickname = nickname;
     }
-    
-    public int getId() {
-        return this.id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public int getMemberId() {
-        return this.memberId;
-    }
-
-    public void setMemberId(int memberId) {
-        this.memberId = memberId;
-    }
-
-    public Date getCreatedAt() {
-        return this.createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-	public String getNickname() {
-		return nickname;
-	}
-
-	public void setNickname(String nickname) {
-		this.nickname = nickname;
-	}
-
 }

--- a/src/main/java/com/zpop/web/global/exception/ExceptionReason.java
+++ b/src/main/java/com/zpop/web/global/exception/ExceptionReason.java
@@ -10,6 +10,7 @@ public enum ExceptionReason {
     // 400
     VALIDATION_ERROR(BAD_REQUEST, "잘못된 입력이 있습니다."),
     CLOSED_MEETING(BAD_REQUEST, "마감된 모임입니다."),
+    SOCIAL_ID_ALREADY_REGISTERED(BAD_REQUEST, "이미 등록된 소셜 계정입니다."),
 
     // 401
     AUTHENTICATION_ERROR(UNAUTHORIZED, "인증 에러"),

--- a/src/main/java/com/zpop/web/service/RegisterService.java
+++ b/src/main/java/com/zpop/web/service/RegisterService.java
@@ -6,40 +6,59 @@ import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.zpop.web.dao.MemberDao;
+import com.zpop.web.dao.NicknameLogDao;
 import com.zpop.web.dao.SocialTypeDao;
 import com.zpop.web.entity.Member;
+import com.zpop.web.entity.NicknameLog;
 import com.zpop.web.entity.SocialType;
+import com.zpop.web.global.exception.CustomException;
+import com.zpop.web.global.exception.ExceptionReason;
 
 @Service
 public class RegisterService {
 	
+	@Autowired
 	private MemberDao memberDao;
+	@Autowired
 	private SocialTypeDao socialTypeDao;
+	@Autowired
+	private NicknameLogDao nicknameLogDao;
 	
 	private final int MAX_NICKNAME_LENGTH = 10;
 	private final String nicknamePattern = "^(?=.*[a-zA-Z0-9가-힣])[a-zA-Z0-9가-힣]{0,10}$";
-	
-	@Autowired
-	public RegisterService(MemberDao memberDao, SocialTypeDao socialTypeDao) {
-		this.memberDao = memberDao;
-		this.socialTypeDao = socialTypeDao;
-	}
-	
+
+
+	@Transactional
 	public Member registerMember(String nickname, String socialId, String LoginType) {
 		
+		Member registeredMember = memberDao.getBySocialId(socialId);
+		if (registeredMember != null){
+			throw new CustomException(ExceptionReason.SOCIAL_ID_ALREADY_REGISTERED);
+		}
 
 		SocialType socialType = socialTypeDao.get(LoginType);
 		int socialTypeId = socialType.getId();
-	
-		Member member = new Member();
-		member.setNickname(nickname);
-		member.setSocialId(socialId);
-		member.setSocialTypeId(socialTypeId);
+
+
+		Member member = Member.builder()
+							.nickname(nickname)
+							.socialId(socialId)
+							.socialTypeId(socialTypeId)
+							.build();
+
 		memberDao.insert(member);
 
-		return memberDao.getBySocialId(socialId);
+		NicknameLog log = NicknameLog.builder()
+									.memberId(member.getId())
+									.nickname(nickname)
+									.build();
+
+		nicknameLogDao.insert(log);
+
+		return member;
 	}
 	
 	public Map<String, Object> checkNicknameValid(String nickname) {

--- a/src/main/resources/mapper/MemberDaoMapper.xml
+++ b/src/main/resources/mapper/MemberDaoMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.zpop.web.dao.MemberDao">
-    <insert id="insert" parameterType="Member">
+    <insert id="insert" parameterType="Member" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO member(socialTypeId, socialId, nickname)
         VALUES (#{socialTypeId}, #{socialId}, #{nickname}) </insert>
     <select id="getById" resultType="Member">

--- a/src/main/resources/static/css/button.css
+++ b/src/main/resources/static/css/button.css
@@ -26,7 +26,7 @@
 .btn-cancel {
   background-color: var(--grey2);
 }
-.btn-dead{
+.btn-disabled{
   cursor:default;
   background-color: var(--grey2);
 }

--- a/src/main/resources/static/css/form.css
+++ b/src/main/resources/static/css/form.css
@@ -113,7 +113,6 @@ input{
 
 .input-text__content-wrapper--correct .input-text__content:focus{
     border-color:var(--tiffany-blue);
-    box-shadow:0px 1px 2px var(--tiffany-blue);
 }
 
 .input-text__content-wrapper--correct + .input__message{

--- a/src/main/resources/templates/meeting/detail.html
+++ b/src/main/resources/templates/meeting/detail.html
@@ -75,7 +75,7 @@
             <div class="meeting__views"  th:text="|조회수${meeting.viewCount}|">조회수</div>
 
             <div class="meeting__btn z-idx-2">
-                <span th:if="${meeting.isClosed == true}" class="btn btn-round btn-join btn-dead" >모집완료</span>
+                <span th:if="${meeting.isClosed == true}" class="btn btn-round btn-join btn-disabled" >모집완료</span>
                 <span th:unless="${meeting.isClosed == true}" th:if="${meeting.isMyMeeting == true}" class="btn btn-round btn-join btn-action modal__on-btn" id="btn-close" data-modal="#modal-wrapper-close">마감하기</span>
                 <span th:unless="${meeting.isClosed == true}" th:if="${meeting.isMyMeeting == false and meeting.hasParticipated == false} " class="btn btn-round btn-join btn-action modal__on-btn " id="btn-participation"  data-modal="#modal-wrapper-participation">참여하기</span>
                 <span th:unless="${meeting.isClosed == true}" th:if="${meeting.isMyMeeting == false and meeting.hasParticipated == true}" class="btn btn-round btn-join btn-action modal__on-btn" id="btn-cancel-participation" data-modal="#modal-wrapper-cancel">참여취소</span>

--- a/src/main/vue/src/assets/css/button.css
+++ b/src/main/vue/src/assets/css/button.css
@@ -8,6 +8,7 @@
   cursor: pointer;
   color: var(--white);
   font-weight: bold;
+  user-select: none;
 }
 
 .btn-round {
@@ -32,8 +33,8 @@
 .btn-cancel {
   background-color: var(--grey2);
 }
-.btn-dead{
-  cursor:default;
+.btn-disabled{
+  cursor:not-allowed;
   background-color: var(--grey2);
 }
 .btn-totop {

--- a/src/main/vue/src/assets/css/form.css
+++ b/src/main/vue/src/assets/css/form.css
@@ -120,7 +120,6 @@ input{
 .input-text__content-wrapper--correct .input-text__content,
 .input-date__content-wrapper--correct .input-text__content{
     border-color:var(--tiffany-blue);
-    box-shadow:0px 1px 10px var(--tiffany-blue);
 }
 
 .input-text__content-wrapper--correct + .input__message,

--- a/src/main/vue/src/components/button/RoundDisabled.vue
+++ b/src/main/vue/src/components/button/RoundDisabled.vue
@@ -2,7 +2,7 @@
 
 <template>
 
-  <span class="btn btn-round btn-dead">
+  <span class="btn btn-round btn-disabled">
     <slot name="content"> default </slot>
   </span>
 

--- a/src/main/vue/src/components/modal/NicknameRegister.vue
+++ b/src/main/vue/src/components/modal/NicknameRegister.vue
@@ -1,0 +1,212 @@
+<template>
+    <div id="modal-register" class="modal-wrapper">
+        <div class="modal">
+            <div class="modal__header">
+                <span class="modal__close-btn icon icon-x" @click="close">닫기</span>
+            </div>
+            <div class="modal__body">
+                <div class="modal__contents">
+                    <Transition name="content1">
+                        <div class="modal__content" v-show="!isRegisteredSuccessful">
+                            <div class="logo-img">
+                                <img src="/images/logo/logo-modal.svg" alt="" class="src">
+                            </div>
+                            <div class="modal-register__nickname-form input-text">
+                                <label class="input-text__label" for="">집합에서 사용할 닉네임을 입력해주세요.</label>
+                                <div class="input-text__content-wrapper"  
+                                v-bind:class="{'input-text__content-wrapper--correct' : nickname.isValid == true ,
+                                'input-text__content-wrapper--error': nickname.isValid  == false} ">
+                                    <input class="input-text__content" type="text" placeholder="최소 2글자, 최대 10글자까지 입력 가능"
+                                        :maxlength="maxNicknameLength" spellcheck="false" :value="nickname.value" @input=nicknameChangeHandler @keydown="keydownHandler">
+                                </div>
+                                <span class="input__message " v-bind:class="{'input__message--appear': message}"> {{ message }} </span>
+                                <span class="btn btn-semiround" :class="{'btn-disabled':!nickname.isValid, 'btn-action':nickname.isValid}" @click.stop="setNickname">닉네임 설정</span>
+                            </div>
+                        </div>
+                    </Transition>
+                    <Transition name="content2">
+                        <div class="modal__content" v-show="isRegisteredSuccessful">
+                            <div class="greetings">
+                                <p>
+                                    <img src="/images/logo/logo-only-text.svg"><span>에 오신걸 환영해요!</span>
+                                </p>
+                                <p>
+                                    😉 집합에 새로오신 ‘<span class="greetings__nickname">나홀로집에</span>’님!
+                                </p>
+                            </div>
+                            <div class="pros">
+                                <div>집합은 이런 점이 좋아요!</div>
+                                <ol>
+                                    <li>1. 간편하게 모임을 만들 수 있어요!</li>
+                                    <li>2. 다양한 카테고리의 모임이 있어요!</li>
+                                    <li>3. 전국 어디든 모일 수 있어요!</li>
+                                </ol>
+                            </div>
+                            <div class="go-home">
+                                <div>그럼 지금부터,</div>
+                                <div>우리만의 교집합을 만들어 볼까요?😆</div>
+                                <span class="btn btn-semiround btn-action" @click.stop="emit('close')">좋아요!</span>
+                            </div>
+                        </div>
+                    </Transition>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue';
+import { useMemberStore } from '../../stores/memberStore';
+const nickname = reactive({
+    value : "",
+    isValid : null,
+})
+const maxNicknameLength = 10;
+const message = ref("");
+const emit = defineEmits(['close']);
+const memberStore = useMemberStore();
+const isRegisteredSuccessful = ref(false);
+
+const close = () => {
+    emit('close');
+}
+
+const setNickname = () => {
+    
+    if(!nickname.isValid){
+        return;
+    }
+    
+    const form = new FormData();
+    form.append('nickname', nickname.value);
+    
+    const url = '/api/register/nickname/set';
+    const options = {
+        method: "POST",
+        body: form,
+    }
+    fetch(url, options)
+    .then(res => {
+            if (!res.ok){
+                throw new ServerException(res);
+            }
+            isRegisteredSuccessful.value = true;
+            memberStore.isAuthenticated();
+    })
+    .catch((err)=> {
+        err.json().then((data)=>{
+            message.value = data.message;
+            nickname.isValid = false;
+        });
+    });
+}
+    
+
+let timer;
+const delay = 300;
+const nicknameChangeHandler = (event) => {
+    nickname.isValid = null;
+    message.value = null;
+    nickname.value = event.target.value;
+    if (timer){
+        clearTimeout(timer);
+    }
+    timer = setTimeout(()=>{
+        try {
+            validateNickname();
+        } catch (error) {
+            nickname.isValid = false;
+            message.value = error.message;
+        }
+    },delay);
+}
+
+const validateNickname = () => {
+    
+    if (nickname.value.length === 0) return;
+
+    if (nickname.value.length > maxNicknameLength){
+        throw new Error('닉네임은 10글자 이하로 입력해주세요!');
+    }
+
+    const nicknameValidExp = /^(?=.*[a-zA-Z0-9가-힣])[a-zA-Z0-9가-힣]{0,10}$/;
+
+    if (!nicknameValidExp.test(nickname.value)) {
+        throw new Error('닉네임은 한글, 숫자, 영어만 조합해주세요!');
+    }
+
+    const form = new FormData();
+    form.append('nickname', nickname.value);
+    const url = '/api/nickname/validation';
+    const options = {
+        method: "POST",
+        body: form,
+    }
+    fetch(url, options)
+    .then(response => {
+        if (response.ok) {
+            return response.json();
+        }
+        else {
+            throw new Error('서버에 오류가 발생했습니다.');
+        }
+    })
+    .then(data => {
+        let result = data.result;
+        console.log(data);
+        if (result === "NICKNAME_VALID") {
+            nickname.isValid = true;
+            message.value ='사용할 수 있는 닉네임이에요!';
+            return;
+        }
+        if (result == "NICKNAME_ALREADY_USED") {
+            throw new Error('이미 사용중인 닉네임이에요!');
+        }
+    })
+    .catch(err=>{
+        nickname.isValid = false;
+        message.value = err.message;
+    })
+}
+
+
+</script>
+
+<style scoped>
+@import url('@/assets/css/component/modal.css');
+/* @import url('@/assets/css/component/modal-2.css'); */
+@import url('@/assets/css/form.css');
+
+
+.content1-enter-active,
+.content1-leave-active {
+  transition: all 0.5s ease;
+}
+
+.content1-enter-from,
+.content1-leave-to {
+  transform:translateX(-100%);
+  opacity: 0;
+}
+
+
+.content2-enter-active,
+.content2-leave-active {
+  transition: all 0.5s ease;
+}
+
+.content2-enter-to,
+.content2-leave-from {
+  transform:translateX(-100%);
+  opacity: 1;
+}
+
+.modal__contents{
+    height:600px; 
+    display:flex; 
+    overflow-x:hidden;
+}
+</style>
+    
+    

--- a/src/main/vue/src/views/LoginProc.vue
+++ b/src/main/vue/src/views/LoginProc.vue
@@ -28,13 +28,24 @@ const memberStore = useMemberStore();
 const route = useRoute();
 const router = useRouter();
 
+const emit = defineEmits(['memberRegisterRequired','close']);
+
 const requestOAuth = () => {
     const oauthLoginUrl = `/api/login/oauth/${route.query.login}?code=${route.query.code}&state=${route.query.state}`;
 
     fetch(oauthLoginUrl)
     .then(res => res.json())
     .then(data => {
-        console.log("성공 : fetch oauthLoginUrl ")
+        console.log("성공 : fetch oauthLoginUrl ");
+
+        if(data.code==="REGISTER_REQUIRED"){
+            emit('memberRegisterRequired');
+            emit('close');
+            router.push({path: '/'});
+            return;
+        }
+
+
         memberStore.setInfo(data);
 
         // router에 있던 리다이렉트 기능이 이쪽으로 옮겨짐

--- a/src/main/vue/src/views/meeting/List.vue
+++ b/src/main/vue/src/views/meeting/List.vue
@@ -11,9 +11,11 @@ import ModalDefault from "@/components/modal/Default.vue";
 import Banner from "../../components/meeting/Banner.vue"
 import { ServerException } from "@/utils/ServerException";
 import LoginProc from "../LoginProc.vue";
+import NicknameRegister from "../../components/modal/NicknameRegister.vue";
+import { useRoute } from "vue-router";
 
 const emit = defineEmits(["throw"]);
-
+const route = useRoute();
 // 검색을 위한 router
 const router = useRouter();
 
@@ -142,6 +144,22 @@ function search(keyword) {
 function closeRequiredKeywordModal() {
   isSearchKeywordNone.value = false;
 }
+
+const isLoginProcOpened = ref(false);
+const isNicknameRegisterOpened = ref(false);
+
+if (route.query.login){
+  isLoginProcOpened.value=true;
+}
+
+function changeLoginProcStatus (){
+  isLoginProcOpened.value = !isLoginProcOpened.value;
+}
+
+function changeNicknameRegisterStatus(){
+  isNicknameRegisterOpened.value = !isNicknameRegisterOpened.value;
+}
+
 </script>
 
 <template>
@@ -170,7 +188,8 @@ function closeRequiredKeywordModal() {
       <LoadingRoller :isShow="state.loadingOn" />
     </div>
   </div>
-  <login-proc/>
+  <login-proc v-show="isLoginProcOpened" @close="changeLoginProcStatus" @memberRegisterRequired="changeNicknameRegisterStatus"/>
+  <nickname-register v-show="isNicknameRegisterOpened" @close="changeNicknameRegisterStatus"/>
 </template>
 
 <style scoped>


### PR DESCRIPTION
## 🛠 작업사항
- 사용자 최초 소셜로그인 시 닉네임 설정 및 계정 등록하는 기능 추가하였음

### 수정 전
- 기존에는 순수 js로만 구현되어있었습니다.
- 기존에는 동일 social id로 계정 추가할 때 별도의 처리 없이 등록이 가능했습니다.

### 수정 후
- vue.js로 프론트쪽 구현했습니다.
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/102606939/214777187-4c57cef5-dd9a-4a72-a94a-c8081bfc9522.png">

- 닉네임 설정이 되면 memberStore의 isAuthenciated()를 호출해서 별도의 리다이렉션이나 refresh없이 header를 갱신할 수 있도록 했습니다.
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/102606939/214777299-d80a7cd2-101c-4134-8e22-9bba01058d2a.png">

- 찬우님이 만드신 CustomException을 사용해서 예외처리했습니다.

## 💡 기타
- 로그인모달과 계정설정 모달의 포멧이 공유되는데, slot을 이용해서 컴포넌트화하는 것이 좋을 것 같습니다.
- 만약에 탈퇴기능 구현된다면, social id 이미 등록되어있을 때 예외 발생하는 로직은 추가적으로 수정 필요합니다. 
