### PR TITLE
[fix] detail page css

### DIFF
--- a/src/main/java/com/zpop/web/utils/ElapsedTimeCalculator.java
+++ b/src/main/java/com/zpop/web/utils/ElapsedTimeCalculator.java
@@ -25,7 +25,7 @@ public final class ElapsedTimeCalculator {
         if (diffTime < ElapsedTimeCalculator.SEC)
         {
             // sec
-            msg = "방금";
+            msg = "방금 전";
         }
         else if ((diffTime /= ElapsedTimeCalculator.SEC) < ElapsedTimeCalculator.MIN)
         {

--- a/src/main/vue/src/assets/css/meeting/component/comment.css
+++ b/src/main/vue/src/assets/css/meeting/component/comment.css
@@ -45,6 +45,9 @@
 	justify-self: flex-end;
 	margin-right:30px;
 }
+.comment__list > li {
+  margin-bottom: 27px;
+}
 @media (min-width: 576px) {
   .comment{
     margin-top: 50px;
@@ -63,6 +66,7 @@
     margin-top: 38px;
   }
 }
+
 
 .comment__list {
   margin-top: 32px;

--- a/src/main/vue/src/views/meeting/Detail.vue
+++ b/src/main/vue/src/views/meeting/Detail.vue
@@ -45,7 +45,7 @@ getDetail();
 }
 @media (min-width: 576px) {
   .content-wrap {
-    padding: 4rem;
+    padding-top: 40px;
   }
 }
 </style>


### PR DESCRIPTION
## 🛠 작업사항
- 모임 상세페이지 데스크탑 사이즈를 740이상으로 정상화
- 댓글 간의 수직간격에 27px 마진을 줌
- 댓글 작성시간의 '방금'을 '방금 전'으로 수정
