### PR TITLE
[FIX]모바일화면에서 간헐적으로 지역카테고리 옵션이 보이는 버그 수정 & 지역옵션선택 색상변경 (main-color)

### DIFF
--- a/src/main/vue/src/components/meeting/option-control/Region.vue
+++ b/src/main/vue/src/components/meeting/option-control/Region.vue
@@ -86,8 +86,7 @@ const updateRegions= () => {
 
 </script>
 
-<style>
-@import url('../../../assets/css/component/select.css');
+<style scoped>
 .region-category {
   width: 220px;
   display: none;

--- a/src/main/vue/src/main.js
+++ b/src/main/vue/src/main.js
@@ -8,8 +8,9 @@ import "./assets/css/reset.css";
 import "./assets/css/style.css";
 import "./assets/css/deco.css";
 import "./assets/css/icon.css";
-import "./assets/css/button.css"
-import "./assets/css/component/tooltip.css"
+import "./assets/css/button.css";
+import "./assets/css/component/tooltip.css";
+import "./assets/css/component/select.css";
 
 
 const app = createApp(App);


### PR DESCRIPTION
## 🛠 작업사항
- 지역카테고리 옵션이 모바일에서 간헐적으로 사라지지 않는 현상을 수정했습니다.
### 수정 전
- 모바일 화면에서 모임글을 클릭하여 상세글보기를 한 뒤 다시 돌아왔을 때 지역카테고리옵션이 보이는 버그가 있었습니다.
- 지역옵션 선택 색상이 true-blue로 되어있었습니다.

### 수정 후
- 확인 결과 region-category에서 select.css를 import하고 있었는데, 이 파일을 main.js에 옮기고 scoped를 주니 개선되었습니다.
- 지역옵션 선택 색상을 main-color로 변경했습니다.
## 💡 기타

