### PR TITLE
refactor: 회원 프로필 조회

### DIFF
--- a/src/main/java/com/zpop/web/controller/LoginController.java
+++ b/src/main/java/com/zpop/web/controller/LoginController.java
@@ -99,14 +99,11 @@ public class LoginController {
 		// 로그인시 알림생성
 		try {
 			int participantId = member.getId();
-			int[] participantIds = participationDao.getListByParticipantId(participantId);
-			
+			int[] participantIds = participationDao.getIdsUnEvaluatedByParticipantId(participantId);
+			// 용도가 평가하지않은 모임 찾기
 			if(participantIds!=null)
 				// for(int p : participantIds)
 					createNotification(participantIds[0],"my-meeting",1);
-			
-
-
 		} catch (ArrayIndexOutOfBoundsException e) {
 		    System.err.println("Error: the array is empty!");
 		}

--- a/src/main/java/com/zpop/web/controller/MemberController.java
+++ b/src/main/java/com/zpop/web/controller/MemberController.java
@@ -133,8 +133,9 @@ public ResponseEntity<EvalDto> rateMember(EvalDto dto, @AuthenticationPrincipal 
 }
 
 @GetMapping("/member/{id}")
-public ProfileResponse getProfile(@PathVariable("id") int id){
-	return service.getParticipant(id);
+public ResponseEntity<ProfileResponse> getProfile(@PathVariable("id") int id){
+	ProfileResponse profile = service.getProfile(id);
+	return ResponseEntity.ok(profile);
 }
 
 

--- a/src/main/java/com/zpop/web/dao/ParticipationDao.java
+++ b/src/main/java/com/zpop/web/dao/ParticipationDao.java
@@ -26,7 +26,8 @@ public interface ParticipationDao {
      */
     List<ParticipationInfoView> getParticipantInfoByMeetingId(int meetingId);
 
-    int[] getListByParticipantId(int participantId);
+    List<Participation> getListByParticipantId(int participantId);
+    int[] getIdsUnEvaluatedByParticipantId(int participantId);
 
 	int countBySearch(String keyword, String option);
 

--- a/src/main/java/com/zpop/web/dto/ProfileResponse.java
+++ b/src/main/java/com/zpop/web/dto/ProfileResponse.java
@@ -1,5 +1,12 @@
 package com.zpop.web.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
 public class ProfileResponse {
     
     private int id;
@@ -7,56 +14,16 @@ public class ProfileResponse {
     private int fame;
     private String profileImg;
     private boolean isResigned;
-    private int participatedMeetingNumber;
+    private int participatedCount;
 
-    public ProfileResponse() {
-    }
 
-    public ProfileResponse(int id, String nickname, int fame, String profileImg, boolean isResigned, int participatedMeetingNumber) {
+
+    public ProfileResponse(int id, String nickname, int fame, String profileImg, boolean isResigned, int participatedCount) {
         this.id = id;
         this.nickname = nickname;
         this.fame = fame;
         this.profileImg = profileImg;
         this.isResigned = isResigned;
-        this.participatedMeetingNumber = participatedMeetingNumber;
+        this.participatedCount = participatedCount;
     }
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-    public String getNickname() {
-        return nickname;
-    }
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-    public int getFame() {
-        return fame;
-    }
-    public void setFame(int fame) {
-        this.fame = fame;
-    }
-    public String getProfileImg() {
-        return profileImg;
-    }
-    public void setProfileImg(String profileImg) {
-        this.profileImg = profileImg;
-    }
-    public boolean isResigned() {
-        return isResigned;
-    }
-    public void setResigned(boolean isResigned) {
-        this.isResigned = isResigned;
-    }
-    public int getParticipatedMeetingNumber() {
-        return participatedMeetingNumber;
-    }
-
-    public void setParticipatedMeetingNumber(int participatedMeetingNumber) {
-        this.participatedMeetingNumber = participatedMeetingNumber;
-    }
-
 }

--- a/src/main/java/com/zpop/web/global/exception/ExceptionReason.java
+++ b/src/main/java/com/zpop/web/global/exception/ExceptionReason.java
@@ -21,7 +21,8 @@ public enum ExceptionReason {
     NOT_JOIN_MEETING(FORBIDDEN, "참여하지 않은 모임입니다"),
 
     // 404
-    NOT_FOUND_MEETING(NOT_FOUND, "존재하지 않는 모임입니다."),
+    NOT_FOUND_MEETING(NOT_FOUND, "존재하지 않는 모임입니다"),
+    NOT_FOUND_MEMBER(NOT_FOUND, "존재하지 않는 사용자입니다"),
 
     // 409
     SOCIAL_ID_ALREADY_REGISTERED(CONFLICT, "이미 등록된 소셜 계정입니다."),

--- a/src/main/java/com/zpop/web/service/DefalutMemberService.java
+++ b/src/main/java/com/zpop/web/service/DefalutMemberService.java
@@ -7,6 +7,8 @@ import com.zpop.web.dto.MyMeetingResponse;
 import com.zpop.web.dto.ProfileResponse;
 import com.zpop.web.entity.*;
 import com.zpop.web.entity.member.MyMeetingView;
+import com.zpop.web.global.exception.CustomException;
+import com.zpop.web.global.exception.ExceptionReason;
 import com.zpop.web.utils.TextDateTimeCalculator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -227,48 +229,39 @@ public class DefalutMemberService implements MemberService {
     }
 
     @Override
-    public ProfileResponse getParticipant(int id) {
-        
-        // id 로 해당 사용자를 찾는다
+    public ProfileResponse getProfile(int id) {
+
         Member member = getById(id);
-        // 만약 id에 해당 사용자가 없다면 404 예외를 얻는다
-        // 만약 탈퇴한 회원이라면 바로 응답하여 탈퇴한 회원임을 사용자에게 보여준다.
         if(member==null)
-            System.out.println("탈퇴한 회원입니다");
-        
-        boolean isResigned;
-        if(member.getResignedAt()!=null)
-            isResigned = true;
-        else 
-            isResigned = false;
+            throw new CustomException(ExceptionReason.NOT_FOUND_MEMBER);
 
-        // 찾아온 멤버 객체에서 id, nickname, fame , imgPath 추출한다
+        if(member.getResignedAt() != null) {
+            return new ProfileResponse(
+                    0,
+                    "",
+                    0,
+                    "",
+                    true,
+                    0
+            );
+        }
+        // 해당 사용자의 모임 참여 횟수 조회
+        int participatedCount = 0;
+        List<Participation> participationList = participationDao.getListByParticipantId(id);
 
-        // 참여 Dao 로 해당 사용자의 참여 리스트 모두 가져온다.
-        List<Participation> participationList = participationDao.getListByMeetingId(id);
+        for(Participation p : participationList) {
+            if( p.getBannedAt()==null && p.getCanceledAt()==null )
+                participatedCount++;
+        }
 
-        int participatedMeetingNumber=0;
-        for(Participation p : participationList)
-            if(p.getBannedAt()!=null && p.getCanceledAt()!=null)
-                participatedMeetingNumber++;
-        
-        // 참여한 모임이 0 개인 경우 바로 응답
-        if(participatedMeetingNumber!=0)
-            System.out.println("banned, canceled meetings");
-        // 밴, 취소한 모임은 개수는 제외한다.
-
-       
-
-        ProfileResponse participant = new ProfileResponse(
-            member.getId(),
-            member.getNickname(),
-            member.getFame(),
-            member.getProfileImagePath(),
-            isResigned,
-            participatedMeetingNumber
-        );
-
-        return participant;
+        return new ProfileResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getFame(),
+                member.getProfileImagePath(),
+                false,
+                participatedCount
+        );;
     }
 
 

--- a/src/main/java/com/zpop/web/service/MemberService.java
+++ b/src/main/java/com/zpop/web/service/MemberService.java
@@ -19,7 +19,7 @@ public interface MemberService {
         List<MyMeetingResponse> getMyGathering(int memberId);
         List<EvalMemberDto> getEvalMember(int meetingId);
         Map<String,Object> getRateData(EvalDto dto);
-        ProfileResponse getParticipant(int id);
+        ProfileResponse getProfile(int id);
 
         Map<String, Object> checkNicknameValid(String nickname);
         int updateNickname(int memberId, String nickname);

--- a/src/main/resources/mapper/ParticipationDaoMapper.xml
+++ b/src/main/resources/mapper/ParticipationDaoMapper.xml
@@ -61,7 +61,13 @@
 		
 	</select>
     
-	<select id="getListByParticipantId" resultType="int">
+	<select id="getListByParticipantId" resultType="com.zpop.web.entity.Participation">
+		SELECT *
+		FROM participation
+		WHERE participantId=#{participantId}
+	</select>
+
+	<select id="getIdsUnEvaluatedByParticipantId" resultType="int">
 		SELECT participantId
 		FROM participation
 		WHERE participantId=#{participantId}

--- a/src/main/vue/src/components/meeting/MemberProfile.vue
+++ b/src/main/vue/src/components/meeting/MemberProfile.vue
@@ -14,9 +14,10 @@ let isReportModalOpened = ref(false);
 
 const state = reactive({
   member: {
+    id: 0,
     nickname: null,
     fame: 0,
-    participatedMeetingNumber: 0,
+    participatedCount: 0,
     profileImg: null,
   },
 });
@@ -84,7 +85,7 @@ function closeModal() {
                 >탈퇴한 회원입니다!</span
               >
               <span v-if="!isResigned"
-                >{{ state.member.participatedMeetingNumber }} 회</span
+                >{{ state.member.participatedCount }} 회</span
               >
               <span v-if="!isResigned">{{ state.member.fame }} 점</span>
             </div>


### PR DESCRIPTION
## 🛠 작업사항
### 회원 프로필 조회와 관련된 백엔드 코드 수정
- 의미에 맞게 변수명, 함수명 수정
- 함수 위치 수정
- DAO 쿼리 사용 목적에 맞게 수정
- 모임 참여횟수 카운트 로직 수정
### 회원 프로필 조회 구현

![스크린샷 2023-01-27 오후 6 53 44](https://user-images.githubusercontent.com/105474635/215057828-5b8093fa-7175-4365-9555-1615ee4b1e9f.png)
다음은 추후 구현할 사항입니다
- `내보내기` 렌더링 여부
- `탈퇴회원`
- 프사 유무