### PR TITLE
[FEAT] comment & reply kebob select menu 완료

### DIFF
--- a/src/main/vue/src/api/comment.js
+++ b/src/main/vue/src/api/comment.js
@@ -34,6 +34,18 @@ async function updateComment(commentId, dataJSONStr){
         return await fetch(`/api/comment/${commentId}`,option);
       }
 /*
+댓글 삭제
+*/
+async function deleteComment(commentId){
+  const option = {
+    method: "DELETE",
+    headers: {"Content-Type": "application/json"},
+        body: "",
+  }
+  return await fetch(`/api/comment/${commentId}`,option);
+}
+
+/*
 답글 등록
 */
 async function registerReply(dataJSONStr){
@@ -46,17 +58,19 @@ async function registerReply(dataJSONStr){
         return await fetch(url,option);
       }
 /*
-댓글 삭제
+답글 수정
 */
-async function deleteComment(commentId){
-        const option = {
-          method: "DELETE",
-          headers: {"Content-Type": "application/json"},
-              body: "",
-        }
-        return await fetch(`/api/comment/${commentId}`,option);
-      }
-
+async function updateReply(replyId, dataJSONStr){
+  const option = {
+    method: "PATCH",
+    headers: {"Content-Type": "application/json"},
+        body: dataJSONStr,
+  }
+  return await fetch(`/api/reply/${replyId}`,option);
+}
+/*
+답글 수정은 댓글 수정을 이용함.
+*/
 export default {
     getCommentList,
     getReplyList,
@@ -64,4 +78,5 @@ export default {
     updateComment,
     deleteComment,
     registerReply,
+    updateReply,
 }

--- a/src/main/vue/src/components/comment/Comment.vue
+++ b/src/main/vue/src/components/comment/Comment.vue
@@ -1,10 +1,10 @@
 <script setup>
   import { nextTick, ref } from 'vue';
-  import ReplyList from "./ReplyList.vue";
   import { useMemberStore } from "@/stores/memberStore";
   import { useLoginModalStore } from "@/stores/loginModalStore";
   import { useReplyStore } from '@/stores/replyStore'
   import { useCommentStore } from '@/stores/CommentStore'
+  import ReplyList from "./ReplyList.vue";
   import InputBox from './InputBox.vue';
   import SelectModal from './SelectModal.vue';
 

--- a/src/main/vue/src/components/comment/Comment.vue
+++ b/src/main/vue/src/components/comment/Comment.vue
@@ -1,125 +1,110 @@
 <script setup>
-import { reactive, ref } from 'vue';
-import ReplyList from "./ReplyList.vue";
-import { onMounted } from 'vue';
-import { useReplyStore } from '@/stores/replyStore'
-import { useCommentStore } from '@/stores/CommentStore'
-import InputBox from './InputBox.vue';
-import SelectModal from './SelectModal.vue';
+  import { nextTick, ref } from 'vue';
+  import ReplyList from "./ReplyList.vue";
+  import { useMemberStore } from "@/stores/memberStore";
+  import { useLoginModalStore } from "@/stores/loginModalStore";
+  import { useReplyStore } from '@/stores/replyStore'
+  import { useCommentStore } from '@/stores/CommentStore'
+  import InputBox from './InputBox.vue';
+  import SelectModal from './SelectModal.vue';
 
-const commentId = props.comment.id;
-const cmtStore = useCommentStore();
-const rplyStore = useReplyStore(); 
-rplyStore.commentId = commentId;
+  const memberStore = useMemberStore();
+  const loginModalStore = useLoginModalStore();
+  const cmtStore = useCommentStore();
+  const rplyStore = useReplyStore(); 
 
-const props = defineProps({
-  comment: Object
-});
-const emit = defineEmits([
-  'counterIncreased',
-  'onEdit'
-]);
-
-cmtStore.addComment(props.comment); //댓글스토어에 댓글 하나씩 채우기
-rplyStore.addComment(props.comment); 
-
-const countOfReply = ref(props.comment.countOfReply);
-
-var hasBox = ref(false); //인풋박스 비노출
-var replyClose = ref(false);//'닫기'버튼 비노출
-var replyWrite = ref(true);//'답글쓰기'버튼 노출
-var replyCnt = ref(false);//'답글4개' 버튼 노출
-var isExpanded = ref(false);//답글리스트 비노출
-
-if (props.comment.countOfReply > 0)
-  replyCnt.value = true;//원댓글이 답글을 가지고있는지 여부. 없으면 '답글0개' 비노출
-
-function toggleReplyCnt() { //'답글4개' <-> '닫기' 전환
-  isExpanded.value = !isExpanded.value;
-  replyClose.value = !replyClose.value; //닫기 노출
-  replyCnt.value = !replyCnt.value;     //카운트 비노출
-  if (replyClose.value)
-    rplyStore.fillRepliesToComment(commentId);//답글스토어에 답글리스트 채우기
-  else {
-    rplyStore.comments[commentId].replyList.length = 0; //전환시 답글배열 초기화
-  } 
-}
-function toggleInputBox() { //'인풋박스' <-> '답글쓰기' 전환
-  isExpanded.value = !isExpanded.value;
-  hasBox.value = !hasBox.value //인풋박스 노출
-}
-
-function increaseCounter() {
-  countOfReply.value++;
-  emit('counterIncreased');
-}
-//답글 등록버튼에서 올라오는 이벤트 처리기
-function registerFinish() {
-  increaseCounter();
-  rplyStore.reloadReply(commentId); //AJAX로 화면갱신
-  hasBox.value = false; //완료후 인풋박스 비노출
-  replyClose.value = true; //닫기 노출
-  replyCnt.value = false;     //카운트 비노출
-  isExpanded.value = true;  //답글리스트 외부마진 넣어줌
-
-}
-/*****************답글 수정 ******************/
-var isB2Active = ref(true)
-var isB3Active = ref(false)
-function setButtonForEdit(){
-      isB2Active.value = !isB2Active.value;
-      isB3Active.value = !isB3Active.value;
-  }
-function onEditReply(e){
-  commentId = e.targetId;
-  inputBoxToggle()
-  setButtonForEdit();
-  const input = inputs["f1"].value;
-  let content = "";
-  rplyStore.comments[groupId].replyList.forEach(element => {
-    if(element.id == replyId){
-      content = element.content;
-      return 0;
+  async function checkLoginStatus(){
+    const isLoggedIn = await memberStore.isAuthenticated();
+    if (!isLoggedIn) {
+      loginModalStore.handleModal();
+      return true;
     }
-  });
-  input.focus();
-  input.value = content + " ";
-}
-function cancelEdit(){
-  const input = inputs["f1"].value;
-  input.focus();
-  input.value = "";
-  setButtonForEdit();
-  cmtStore.selectModalStatus[commentId] = true;
-}
-function saveEdit(){
-  const data = {};
-  data.id = commentId; 
-  const input = inputs['f1'].value;
-  data.content = input.value;
-  const dataJSONStr = JSON.stringify(data);
-  api.comment.updateComment(commentId, dataJSONStr).then((res) => {
-    if (res.ok) {
-      console.log("댓글 수정됨");
-      cmtStore.reloadComment(mtDetailStore,mtDetailStore.id)
-      input.value = "";
-      input.focus();
-    } else alert("시스템 장애로 등록이 안되고 있습니다");
-  });
-}
-/*****************셀렉트 모달 열고 닫기**********************/
-cmtStore.initSelectModal();
-function toggleSelectModal(){
-  if(cmtStore.selectModalStatus[commentId]){
-    cmtStore.openSelectModal(commentId)
   }
-  else{
-    cmtStore.initSelectModal();
+ 
+  const props = defineProps({
+    comment: Object
+  });
+  const emit = defineEmits([
+    'counterIncreased',
+    'onEdit',
+  ]);
+
+  const commentId = props.comment.id;
+  rplyStore.commentId = commentId;
+
+  cmtStore.addComment(props.comment); //댓글스토어에 댓글 하나씩 채우기
+  rplyStore.addComment(props.comment); 
+
+  const countOfReply = ref(props.comment.countOfReply);
+
+  var hasBox = ref(false); //인풋박스 비노출
+  var replyClose = ref(false);//'닫기'버튼 비노출
+  var replyWrite = ref(true);//'답글쓰기'버튼 노출
+  var replyCnt = ref(false);//'답글4개' 버튼 노출
+  var isExpanded = ref(false);//답글리스트 비노출
+
+  if (props.comment.countOfReply > 0)
+    replyCnt.value = true;//원댓글이 답글을 가지고있는지 여부. 없으면 '답글0개' 비노출
+
+    
+  function toggleReplyCnt() { //'답글4개' <-> '닫기' 전환
+    isExpanded.value = !isExpanded.value;
+    replyClose.value = !replyClose.value; //닫기 노출
+    replyCnt.value = !replyCnt.value;     //카운트 비노출
+    if (replyClose.value)
+    rplyStore.fillRepliesToComment(commentId);//답글스토어에 답글리스트 채우기
+    else {
+      rplyStore.comments[commentId].replyList.length = 0; //전환시 답글배열 초기화
+    } 
   }
-}
-function editComment(e){
-    emit('onEdit',e)
-}
+  const inputTemplate = ref();
+  var inputBox = null;
+  var isB2Active = ref(true)
+  var isB3Active = ref(false)
+  async function toggleInputBox() { //'인풋박스' <-> '답글쓰기' 전환
+    if(await checkLoginStatus())
+        return
+    isExpanded.value = !isExpanded.value;
+    hasBox.value = !hasBox.value //인풋박스 노출
+    if(!inputBox){
+        inputBox = inputTemplate.value.textInputRef;//자식컴포넌트에서 객체받아옴
+        await nextTick();
+        inputBox.focus();
+      }
+      else 
+        inputBox = null;
+  }
+
+  function increaseCounter() {
+    countOfReply.value++;
+    emit('counterIncreased');
+  }
+  //답글 등록버튼에서 올라오는 이벤트 처리기
+  function registerFinish() {
+    increaseCounter();
+    rplyStore.reloadReply(commentId); //AJAX로 화면갱신
+    hasBox.value = false; //완료후 인풋박스 비노출
+    replyClose.value = true; //닫기 노출
+    replyCnt.value = false;     //카운트 비노출
+    isExpanded.value = true;  //답글리스트 외부마진 넣어줌
+
+  }
+
+  /*****************셀렉트 모달 열고 닫기**********************/
+  cmtStore.initSelectModal();
+  async function toggleSelectModal(){
+    if(await checkLoginStatus())
+      return
+    if(cmtStore.selectModalStatus[commentId]){
+      cmtStore.openSelectModal(commentId)
+    }
+    else{
+      cmtStore.initSelectModal();
+    }
+  }
+  function editComment(e){
+      emit('onEdit',e)
+  }
 </script>
 
 <template>
@@ -154,7 +139,10 @@ function editComment(e){
   </div>
   <section class="reply" :class="{ 'no-margin': !isExpanded }">
     <!--여기서 답글 inputBox에 보내는 객체는 댓글(comment)이지만 받는쪽 이름인 답글(reply)에 맞춰줌-->
-    <InputBox :reply="comment" v-show="hasBox" 
+    <InputBox 
+      v-show="hasBox" 
+      ref="inputTemplate"
+      :reply="comment" 
       :isB2Active="isB2Active"
       :isB3Active="isB3Active"
       @cancelClicked="toggleInputBox"

--- a/src/main/vue/src/components/comment/CommentModal.vue
+++ b/src/main/vue/src/components/comment/CommentModal.vue
@@ -17,7 +17,15 @@ const props = defineProps({
   groupId: Number
 });
 const emit = defineEmits(["closeModal", "commentDeleted"]);
+
 let confirmMsg = ref("");
+let deleteMsg = ref("");
+
+if(props.groupId)
+  deleteMsg.value = "답글"
+else 
+  deleteMsg.value = "댓글"
+
 
 async function onClickYes() {
   switch (props.selectType) {
@@ -25,7 +33,7 @@ async function onClickYes() {
       await deleteComment(props.commentId);
       break;
     case "신고":
-      await alert("신고처리함수동작"); //TODO: 임우빈
+      //신고는 별도 콤포넌트에서 처리
       break;
   }
 }
@@ -61,22 +69,12 @@ function closeModalFooterType() {
     
     <template v-if="props.selectType === '삭제'" #modal-body>
       <div v-if="!confirmMsg">
-        <p class="confirm">댓글을 삭제하시겠어요?</p>
+        <p class="confirm">{{ deleteMsg }}을 삭제하시겠어요?</p>
       </div>
       <div v-else>
         <p class="confirm">{{ confirmMsg }}</p>
       </div>
     </template>
-
-    <template v-if="props.selectType === '신고'" #modal-body>
-      <div v-if="!confirmMsg">
-        <p class="confirm">이 모달은 임시로 띄운 것. 이 자리에 신고모달을 넣음</p>
-      </div>
-      <div v-else>
-        <p class="confirm">{{ confirmMsg }}</p>
-      </div>
-    </template>
-    
 
     <template v-if="modalFooterType === 0" #modal-footer>
       <div @click="emit('closeModal')">아니오</div>

--- a/src/main/vue/src/components/comment/InputBox.vue
+++ b/src/main/vue/src/components/comment/InputBox.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import { defineProps, defineEmits, ref, onMounted } from 'vue';
+    import { ref } from 'vue';
     import api from "@/api";
     import { useReplyStore} from '@/stores/replyStore'
     import { useMeetingDetailStore } from "@/stores/meetingDetailStore";
@@ -13,7 +13,8 @@
     });
     const emit = defineEmits([
         'cancelClicked',
-        'registerCompleted'
+        'registerCompleted',
+        'editSaveClicked'
     ]);
     let groupId = 0;
     if(props.reply.groupId == 0)
@@ -21,13 +22,10 @@
     else 
         groupId = props.reply.groupId;
 
-    const inputs = {f1:ref()}
-    onMounted(() => {
-        const input = inputs['f1'].value;
-        input.focus();
-    })
-
+    const textInputRef = ref();
     
+    defineExpose({textInputRef});
+
     function cancelWrite(){
         emit('cancelClicked');
     }
@@ -37,7 +35,11 @@
         data.meetingId = props.reply.meetingId;
         data.parentCommentId = props.reply.id;
         data.groupId = groupId;
-        const inputBox =  inputs['f1'].value;
+        const inputBox =  textInputRef.value;
+        if(inputBox.value===""){
+            alert("글을 입력해주세요")
+            return 0;
+        }
         data.content = inputBox.value;
         const dataJSONStr = JSON.stringify(data);
         api.comment.registerReply(dataJSONStr)
@@ -60,18 +62,18 @@
         id="reply-text"
         class="reply__input"
         name="reply-input"
-        placeholder="답글을 입력하세요." :ref="inputs.f1"></textarea>
+        placeholder="답글을 입력하세요." ref="textInputRef"></textarea>
         <div class="reply__btn-container">
             <span   class="reply__btn btn btn-round btn-cancel cancel-btn" 
                 @click="cancelWrite"
             >취소하기</span>
             <span   v-if="isB2Active"
                 class="reply__btn btn btn-round btn-action" 
-                @click="registerReply('f1')"
+                @click="registerReply"
             >등록하기</span>
             <span   v-if="isB3Active"
                 class="reply__btn btn btn-round btn-action"
-                @click="saveEdit()"
+                @click="emit('editSaveClicked')"
             >저장하기</span
         >
         </div>

--- a/src/main/vue/src/components/comment/InputBox.vue
+++ b/src/main/vue/src/components/comment/InputBox.vue
@@ -26,10 +26,6 @@
     
     defineExpose({textInputRef});
 
-    function cancelWrite(){
-        emit('cancelClicked');
-    }
-
     function registerReply(){
         const data = {};
         data.meetingId = props.reply.meetingId;
@@ -65,7 +61,7 @@
         placeholder="답글을 입력하세요." ref="textInputRef"></textarea>
         <div class="reply__btn-container">
             <span   class="reply__btn btn btn-round btn-cancel cancel-btn" 
-                @click="cancelWrite"
+                @click="emit('cancelClicked')"
             >취소하기</span>
             <span   v-if="isB2Active"
                 class="reply__btn btn btn-round btn-action" 

--- a/src/main/vue/src/components/comment/Reply.vue
+++ b/src/main/vue/src/components/comment/Reply.vue
@@ -1,11 +1,11 @@
 <script setup>
   import { nextTick,ref} from 'vue';
   import api from "@/api";
-  import InputBox from './InputBox.vue';
-  import SelectModal from './SelectModal.vue';
   import { useMemberStore } from "@/stores/memberStore";
   import { useLoginModalStore } from "@/stores/loginModalStore";
   import { useReplyStore } from '@/stores/ReplyStore'
+  import InputBox from './InputBox.vue';
+  import SelectModal from './SelectModal.vue';
   
   const memberStore = useMemberStore();
   const loginModalStore = useLoginModalStore();

--- a/src/main/vue/src/components/comment/Reply.vue
+++ b/src/main/vue/src/components/comment/Reply.vue
@@ -1,12 +1,26 @@
 <script setup>
-  import { defineProps,ref} from 'vue';
+  import { nextTick,ref} from 'vue';
+  import api from "@/api";
   import InputBox from './InputBox.vue';
   import SelectModal from './SelectModal.vue';
+  import { useMemberStore } from "@/stores/memberStore";
+  import { useLoginModalStore } from "@/stores/loginModalStore";
   import { useReplyStore } from '@/stores/ReplyStore'
+  
+  const memberStore = useMemberStore();
+  const loginModalStore = useLoginModalStore();
+  const rplyStore = useReplyStore();
+  
+  async function checkLoginStatus(){
+    const isLoggedIn = await memberStore.isAuthenticated();
+    if (!isLoggedIn) {
+      loginModalStore.handleModal();
+      return true;
+    }
+  }
 
   const replyId = props.reply.id;
   const groupId = props.reply.groupId;
-  const rplyStore = useReplyStore();
 
   const props = defineProps({
     reply:Object
@@ -15,10 +29,20 @@
 
   var hasBox = ref(false);
   var replyWrite = ref(true)
-
-  function inputBoxToggle() { //'인풋박스' <-> '답글쓰기' 전환
+  const inputTemplate = ref();
+  var inputBox = null;
+  async function inputBoxToggle() { //'인풋박스' <-> '답글쓰기' 전환
+    if(await checkLoginStatus())
+        return
     replyWrite.value= !replyWrite.value;
     hasBox.value = !hasBox.value;
+    if(!inputBox){
+      inputBox = inputTemplate.value.textInputRef;//자식컴포넌트에서 객체받아옴
+      await nextTick();
+      inputBox.focus();
+    }
+    else 
+      inputBox = null;
   }
   //답글 등록버튼에서 올라오는 이벤트 처리기
   function registerFinish(){
@@ -27,18 +51,18 @@
     emit('counterIncreased');
   }
   /*****************답글 수정 ******************/
-  const inputs = { f1: ref() };
+  const isEdited = ref(false);
+
   var isB2Active = ref(true)
   var isB3Active = ref(false)
   function setButtonForEdit(){
         isB2Active.value = !isB2Active.value;
         isB3Active.value = !isB3Active.value;
     }
-  function onEditReply(){
+  async function onEditReply(){
+    isEdited.value = true;
     inputBoxToggle()
     setButtonForEdit();
-    const inputBoxComponent = inputs["f1"].value;
-    console.log(inputBoxComponent.inputs)
     let content = "";
     rplyStore.comments[groupId].replyList.forEach(element => {
       if(element.id == replyId){
@@ -46,34 +70,35 @@
         return 0;
       }
     });
-    //input.focus();
-    //input.value = content + " ";
+    inputBox.value = content + " ";
+  
   }
   function cancelEdit(){
-    const input = inputs["f1"].value;
-    input.focus();
-    input.value = "";
-    setButtonForEdit();
-    cmtStore.selectModalStatus[groupId] = true;
+    inputBox.value = "";
+    if(isB3Active)
+      setButtonForEdit();
+    isEdited.value = false;
+    rplyStore.comments[groupId].selectModalStatus[replyId] = true;
+    inputBoxToggle();
   }
   function saveEdit(){
     const data = {};
-    data.id = groupId; 
-    const input = inputs['f1'].value;
-    data.content = input.value;
+    data.id = replyId; 
+    data.content = inputBox.value;
     const dataJSONStr = JSON.stringify(data);
-    api.comment.updateComment(groupId, dataJSONStr).then((res) => {
+    api.comment.updateReply(replyId, dataJSONStr).then((res) => {
       if (res.ok) {
-        console.log("댓글 수정됨");
-        cmtStore.reloadComment(mtDetailStore,mtDetailStore.id)
-        input.value = "";
-        input.focus();
+        console.log("답글 수정됨");
+        rplyStore.reloadReply(groupId);
+        inputBox.value = "";
       } else alert("시스템 장애로 등록이 안되고 있습니다");
     });
   }
   /*****************셀렉트 모달 열고 닫기**********************/
   rplyStore.initSelectModal(groupId);
-  function toggleSelectModal(){
+  async function toggleSelectModal(){
+    if(await checkLoginStatus())
+        return
     if(rplyStore.comments[groupId].selectModalStatus[replyId]){
       rplyStore.openSelectModal(replyId, groupId)
     }
@@ -87,7 +112,7 @@
      <div class="profile select-box">
         <span class="profile__image"></span>
         <span class="profile__nickname profile__nickname">{{ reply.nickname }}</span>
-        <span class="profile__time">{{ reply.elapsedTime }}</span>
+        <span class="profile__time">{{ reply.updatedAt?reply.elapsedTime+' (수정됨)':reply.elapsedTime }}</span>
         <button @click="toggleSelectModal"></button>
         <SelectModal 
             v-if="!rplyStore.comments[groupId].selectModalStatus[replyId]" 
@@ -96,26 +121,26 @@
             :groupId="groupId"
             @onEdit="onEditReply" 
         />
-        <!-- <SelectModal :role="member" v-else v-show="!isSelectModalClosed"/> -->
     </div>
-    <div class="reply-container">
+    <div v-show="!isEdited" class="reply-container">
         <span class="reply__to">{{reply.parentNickname?'@'+reply.parentNickname:reply.parentNickname }}</span>
         <span class="reply__content">{{reply.content}}</span>
     </div>
     <div class="reply__replies">
         <span class="pointer underline" 
           v-show="replyWrite"
-          @click="inputBoxToggle('replyWrite')" 
+          @click="inputBoxToggle" 
         >답글 달기</span> 
     </div>
     <InputBox 
       v-show="hasBox" 
-      :ref="inputs.f1"  
+      ref="inputTemplate"  
       :reply="props.reply" 
       :isB2Active="isB2Active"
       :isB3Active="isB3Active"
-      @cancelClicked="inputBoxToggle" 
+      @cancelClicked="cancelEdit" 
       @registerCompleted="registerFinish" 
+      @editSaveClicked="saveEdit"
     />
 </template>
 <style >

--- a/src/main/vue/src/components/comment/ReplyList.vue
+++ b/src/main/vue/src/components/comment/ReplyList.vue
@@ -10,11 +10,6 @@ const rplyStore = useReplyStore();
 const emit = defineEmits([
   'counterIncreased'
 ]);
-
-
-function increaseCounter(){
-  emit('counterIncreased');
-}
 </script>
 
 <template>
@@ -22,7 +17,7 @@ function increaseCounter(){
     <li v-for="(reply, index) in rplyStore.comments[commentId].replyList" :key="index"> 
       <Reply 
         :reply="reply" 
-        @counterIncreased="increaseCounter"
+        @counterIncreased="emit('counterIncreased')"
       />
     </li>
 </ul>

--- a/src/main/vue/src/components/comment/SelectModal.vue
+++ b/src/main/vue/src/components/comment/SelectModal.vue
@@ -7,6 +7,12 @@
     const cmtStore = useCommentStore();
     const props = defineProps(['isMyComment', 'commentId', 'groupId']);
     const emit = defineEmits(['onEdit']);
+
+    let reportMsg = ref("");
+    if(props.groupId)
+        reportMsg.value = "답글"
+    else 
+        reportMsg.value = "댓글"
     
     // 셀렉트 모달 on/off
     let selectModalOn = ref(true);
@@ -62,7 +68,7 @@
 
     <div v-if="!isMyComment" v-show="selectModalOn" class="modal-select select-box__options comment__kebob">
         <div class="modal-select__contents modal-select__contents--report"
-                @click="onClickReportSelectOption">댓글 신고
+                @click="onClickReportSelectOption">{{ reportMsg }} 신고
             <span class="icon icon-siren-red"></span>
         </div>
     </div>


### PR DESCRIPTION
## 🛠 작업사항
- 댓글/답글 수정/삭제 케밥기능 구현 완료
- 비로그인시 댓글/답글 각종 기능 차단하고 로그인화면으로 보냄
- 비로그인시 댓글리스트와 답글 리스트만 볼 수 있도록 허용

## 남은 TODO
- 모든 AJAX콜을 try-catch로 전환하여 예외처리보강(alert대신 모달로 안내함)
- 댓글/답글의 내용이 비어있는 상태에서 등록버튼을 누를때 (귀찮아서) alert경고창이 뜨도록한 것을 추후 모달로 변경
- 댓글 삭제시 달려있는 답글을 그대로 두고 댓글만 삭제하고 내용을 (삭제됨)으로 표시할지 여부 결정
