### PR TITLE
feat: 모임 내보내기 백엔드

### DIFF
--- a/src/main/java/com/zpop/web/controller/MeetingController.java
+++ b/src/main/java/com/zpop/web/controller/MeetingController.java
@@ -179,4 +179,14 @@ public class MeetingController {
 		service.delete(id, memberId);
 		return ResponseEntity.noContent().build();
 	}
+
+	@DeleteMapping("/kick")
+	public ResponseEntity<Void> kick(
+			@AuthenticationPrincipal ZpopUserDetails userDetails,
+			@RequestBody KickDto dto
+	) {
+		int memberId = userDetails.getId();
+		service.kick(dto.getMeetingId(), memberId, dto.getParticipantId());
+		return ResponseEntity.noContent().build();
+	}
 }

--- a/src/main/java/com/zpop/web/dto/KickDto.java
+++ b/src/main/java/com/zpop/web/dto/KickDto.java
@@ -1,0 +1,15 @@
+package com.zpop.web.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class KickDto {
+    @Min(value = 1)
+    @NotNull
+    private int meetingId;
+    @Min(value = 1)
+    @NotNull
+    private int participantId;
+}

--- a/src/main/java/com/zpop/web/global/exception/ExceptionReason.java
+++ b/src/main/java/com/zpop/web/global/exception/ExceptionReason.java
@@ -27,7 +27,8 @@ public enum ExceptionReason {
 
     // 409
     SOCIAL_ID_ALREADY_REGISTERED(CONFLICT, "이미 등록된 소셜 계정입니다."),
-    ALREADY_PARTICIPATED(CONFLICT, "이미 참여한 모임입니다.");
+    ALREADY_PARTICIPATED(CONFLICT, "이미 참여한 모임입니다."),
+    ALREADY_KICKED(CONFLICT, "이미 강퇴한 참여자입니다");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/zpop/web/service/DefaultMeetingService.java
+++ b/src/main/java/com/zpop/web/service/DefaultMeetingService.java
@@ -317,13 +317,15 @@ public class DefaultMeetingService implements MeetingService {
 	}
 
 	@Override
-	public boolean kick(int id, int participantId, Member member) {
+	public boolean kick(int id, int hostId, int participantId) {
 		Meeting foundMeeting = findById(id);
 
-		int memberId = member.getId();
+		if (foundMeeting.getRegMemberId() != hostId)
+			throw new CustomException(ExceptionReason.AUTHORIZATION_ERROR);
 
-		if (foundMeeting.getRegMemberId() != memberId)
-			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "권한이 없습니다");
+		// 자기자신을 강퇴하려 할 때
+		if (hostId == participantId)
+			throw new CustomException(ExceptionReason.VALIDATION_ERROR);
 
 		List<Participation> participations = participationDao.getListByMeetingId(id);
 
@@ -335,25 +337,12 @@ public class DefaultMeetingService implements MeetingService {
 				break;
 			}
 		}
-
+		// 내보내기 대상이 없거나, 취소했다면 NOT_JOIN_MEETING
 		if (kickTarget == null || kickTarget.getCanceledAt() != null)
-			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "모임에 참여하지 않는 회원입니다");
-
+			throw new CustomException(ExceptionReason.NOT_JOIN_MEETING);
+		// 이미 강퇴한 참여자
 		if (kickTarget.getBannedAt() != null)
-			throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 강퇴된 회원입니다");
-
-		// 탈퇴한 회원인지 확인 후
-		// 탈퇴한 회원이라면 참여 취소처리한다.
-		int kickTargetMemberId = kickTarget.getParticipantId();
-		Member kickTargetMember = memberDao.getById(kickTargetMemberId);
-		if (kickTargetMember.getResignedAt() != null) {
-			participationDao.updateCanceledAt(kickTargetMemberId);
-			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다");
-		}
-
-		// 자기자신을 강퇴하려 할 때
-		if (kickTargetMemberId == member.getId())
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "자기 자신을 내보낼 수 없습니다");
+			throw new CustomException(ExceptionReason.ALREADY_KICKED);
 
 		participationDao.updateBannedAt(kickTarget.getId());
 

--- a/src/main/java/com/zpop/web/service/MeetingService.java
+++ b/src/main/java/com/zpop/web/service/MeetingService.java
@@ -118,20 +118,19 @@ public interface MeetingService {
 	/**
 	 * 참여자를 내보내기.
 	 * 
-	 * 해당 participantId의 참여자를 주최자가 내보낸다.
+	 * 해당 participantId의 참여자(탈퇴 포함)를 주최자가 내보낸다.
 	 * 만약 존재하지 않는 id의 모임이거나, 모임이 이미 삭제 되었다면, 예외를 던진다.
 	 * {@link Meeting 모임}의 id와 주최자의 id가 일치하지 않는다면, 내보낼 수 없다.
 	 * {@link Participation 참여자}들 중, participantId가 존재하지 않는다면, 예외를 던진다.
 	 * {@link Participation 참여자}가 이미 내보내졌다면, 예외를 던진다.
-	 * {@link Member 참여자}가 만약 탈퇴 회원이라면, 참여 취소 처리후 예외를 던진다.
 	 * 또 자기자신을 내보낼 수 없다.
 	 * 
 	 * @param id 모임 아이디
+	 * @param hostId 주최자 아이디
 	 * @param participantId 참여자 아이디
-	 * @param hostId 주최자 아이디  
 	 * @return 성공 여부
 	 */
-	boolean kick(int id, int participantId, Member member); //TODO: 시큐리티
+	boolean kick(int id, int hostId, int participantId);
 
 	/**
 	 * 모임을 마감하기.

--- a/src/test/java/com/zpop/web/service/DefaultMeetingServiceTest.java
+++ b/src/test/java/com/zpop/web/service/DefaultMeetingServiceTest.java
@@ -291,7 +291,7 @@ class DefaultMeetingServiceTest {
         given(memberDao.getById(anyInt())).willReturn(new Member());
 
         // when
-        boolean result = service.kick(meetingId, participantId, member);
+        boolean result = service.kick(meetingId, member.getId(), participantId);
 
         // then
         assertThat(result).isEqualTo(true);
@@ -311,7 +311,7 @@ class DefaultMeetingServiceTest {
 
         //when
         ResponseStatusException e = assertThrows(ResponseStatusException.class,
-            () -> service.kick(meetingId, participantId, member));
+            () -> service.kick(meetingId, member.getId(), participantId));
         
         //then
         assertThat(e.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -334,7 +334,7 @@ class DefaultMeetingServiceTest {
 
         //when
         ResponseStatusException e = assertThrows(ResponseStatusException.class,
-            () -> service.kick(meetingId, participantId, member));
+            () -> service.kick(meetingId, member.getId(), participantId));
         
         //then
         assertThat(e.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
@@ -362,7 +362,7 @@ class DefaultMeetingServiceTest {
 
         //when
         ResponseStatusException e = assertThrows(ResponseStatusException.class,
-            () -> service.kick(meetingId, participantId, member));
+            () -> service.kick(meetingId, member.getId(), participantId));
 
         //then
         assertThat(e.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -392,7 +392,7 @@ class DefaultMeetingServiceTest {
 
         //when
         ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> service.kick(meetingId, participantId, member));
+                () -> service.kick(meetingId, member.getId(), participantId));
 
         //then
         assertThat(e.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -423,7 +423,7 @@ class DefaultMeetingServiceTest {
 
         //when
         ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> service.kick(meetingId, participantId, member));
+                () -> service.kick(meetingId, member.getId(), participantId));
 
         //then
         assertThat(e.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
@@ -458,7 +458,7 @@ class DefaultMeetingServiceTest {
 
         //when
         ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> service.kick(meetingId, participantId, member));
+                () -> service.kick(meetingId, member.getId(), participantId));
 
         //then
         assertThat(e.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -489,7 +489,7 @@ class DefaultMeetingServiceTest {
 
         //when
         ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> service.kick(meetingId, participantId, member));
+                () -> service.kick(meetingId, member.getId(), participantId));
 
         //then
         assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
## 🛠 작업사항
### 모임 내보내기
-  백엔드 재구현입니다
- 지운 `TempMeetingController`에 있던 매핑을 `MeetingController`에 추가했읍니다
- 탈퇴 회원도 내보낼 수 있게 기획에 따라 수정했습니다
- 인자에 시큐리티를 반영(Member member -> int hostId)했습니다