### PR TITLE
style: 모임 썸네일 hover & active css

### DIFF
--- a/src/main/vue/src/components/meeting/Thumbnail.vue
+++ b/src/main/vue/src/components/meeting/Thumbnail.vue
@@ -73,6 +73,15 @@ h3 ,span, li{
   }
 }
 
+.meeting > a:hover {
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px;
+}
+
+.meeting > a:active {
+  box-shadow: rgba(0, 0, 0, 0.06) 0px 2px 4px 0px inset;
+}
+
+
 .meeting__header {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 🛠 작업사항
- 모임 썸네일에 마우스를 올릴 때, 클릭할 때 우아한 그림자를 적용했습니다
<img width="556" alt="스크린샷 2023-01-31 오후 12 15 43" src="https://user-images.githubusercontent.com/105474635/215657329-af945e32-9e24-4a5b-85dc-faeacb5dd5f4.png">
