### PR TITLE
[FIX] 마이 프로필에서 프로필 사진 업데이트 시 사용자 프로필이 업데이트되지 않는 부분 수정

### DIFF
--- a/src/main/java/com/zpop/web/controller/MemberController.java
+++ b/src/main/java/com/zpop/web/controller/MemberController.java
@@ -143,15 +143,17 @@ public ResponseEntity<ProfileResponse> getProfile(@PathVariable("id") int id){
 
 @PostMapping("/upload/profile")
 @ResponseBody //ㅠㅠ
-public ResponseEntity<?> uploadFile(@NotNull MultipartFile file
+public ResponseEntity<ProfileFile> uploadFile(@NotNull MultipartFile file
 		, @NotNull @NotEmpty String path
-		, HttpServletRequest request) throws IOException {
+		, HttpServletRequest request
+		, @AuthenticationPrincipal ZpopUserDetails userDetails) throws IOException {
 	String realPath = request.getServletContext().getRealPath(path);
 	System.out.println(realPath);
 
-	ProfileFile profileFile = service.uploadFile(file, realPath);
-	System.out.println(path);
-	return ResponseEntity.ok(200);
+	int memberId = userDetails.getId();
+	System.out.println(userDetails);
+	ProfileFile profileFile = service.uploadFile(file, realPath, memberId);
+	return ResponseEntity.ok(profileFile);
 }
 
 }

--- a/src/main/java/com/zpop/web/dao/MemberDao.java
+++ b/src/main/java/com/zpop/web/dao/MemberDao.java
@@ -24,7 +24,6 @@ public interface MemberDao {
 
 	int insert(Member member);
 
-	int update(Member member);
 	int countBySearch(String keyword, String option, Integer period, Date minDate);
 	int count(int socialTypeId);
 
@@ -45,4 +44,6 @@ public interface MemberDao {
 	int countNotDeleted();
 
 	int countByNotResigned();
+
+	void updateProfileImagePath(int memberId, String profileImagePath);
 }

--- a/src/main/java/com/zpop/web/entity/ProfileFile.java
+++ b/src/main/java/com/zpop/web/entity/ProfileFile.java
@@ -1,12 +1,18 @@
 package com.zpop.web.entity;
 
-import lombok.*;
-
 import java.sql.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
 @ToString
+@Builder
+@AllArgsConstructor
 public class ProfileFile {
 
     private int id;

--- a/src/main/java/com/zpop/web/service/MemberService.java
+++ b/src/main/java/com/zpop/web/service/MemberService.java
@@ -24,6 +24,6 @@ public interface MemberService {
         Map<String, Object> checkNicknameValid(String nickname);
         int updateNickname(int memberId, String nickname);
 
-        ProfileFile uploadFile(MultipartFile file, String path) throws IOException;
+        ProfileFile uploadFile(MultipartFile file, String path, int memberId) throws IOException;
 }
 

--- a/src/main/java/com/zpop/web/utils/FileNameGenerator.java
+++ b/src/main/java/com/zpop/web/utils/FileNameGenerator.java
@@ -15,7 +15,7 @@ public class FileNameGenerator {
 
     public String getFileNameWithDateTime(){
         Date currentDate = new Date();
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy_MM_dd_HH_ss_SSS"); 
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy_MM_dd_HH_mm_ss_SSS"); 
         String dateString = simpleDateFormat.format(currentDate);
 
         return String.format("%s_%s.%s",this.prefix,dateString,this.extension);

--- a/src/main/resources/mapper/MemberDaoMapper.xml
+++ b/src/main/resources/mapper/MemberDaoMapper.xml
@@ -130,6 +130,11 @@
 			separator=",">#{id}</foreach>
 		</where>
 	</update>
+	<update id="updateProfileImagePath">
+		UPDATE member
+        SET profileImagePath =#{profileImagePath}
+        WHERE id = #{memberId}
+	</update>
 	<select id="countCreatedAtPerDay" resultType="CountPerDateDto">
 		SELECT
 			convert(createdAt, date) AS date,

--- a/src/main/vue/src/assets/css/component/header.css
+++ b/src/main/vue/src/assets/css/component/header.css
@@ -203,12 +203,14 @@
 .header__profile button > img {
   width: 32px;
   flex: 0 0 32px;
+  border-radius: 16px;
 }
 
 @media (min-width: 576px) {
   .header__profile button > img {
     width: 40px;
     flex: 0 0 40px;
+    border-radius: 20px;
   }
 }
 

--- a/src/main/vue/src/components/header/Profile.vue
+++ b/src/main/vue/src/components/header/Profile.vue
@@ -1,6 +1,8 @@
 <template>
     <li class="header__profile select-box">
-        <button><img alt="프로필" src="../../../public/images/icon/user-profile.svg" @click="onProfileClick"></button>
+        <button><img class="header__profile-img" alt="프로필" 
+            :src="profileImagePath ? profileImagePath : '../../../public/images/icon/user-profile.svg'" 
+            @click="onProfileClick"></button>
         <ul class="select-box__options select-box__options--right select-box__options--header" v-show="isOpened">
             <!--li 말고 div 박스 전체로 -->
             <li><router-link to="/my-profile">내 프로필</router-link></li>
@@ -22,6 +24,7 @@ import { useRouter } from 'vue-router';
 const router = useRouter();
 const headerStore = useHeaderStore();
 const memberStore = useMemberStore();
+
 const isOpened = computed(()=>{
     return headerStore.isProfileOpened;
 })
@@ -29,6 +32,15 @@ const onProfileClick = () => {
     headerStore.closeAllExcept('Profile')
     headerStore.changeProfileState();
 }
+
+const profileImagePath = computed(()=>{
+    if (memberStore.profileImagePath==='' || memberStore.profileImagePath===null){
+        return false;
+    }
+    else{
+        return `/image/profile/${memberStore.profileImagePath}`
+    } 
+})
 
 const onLogoutClick = () => {
     const request = getLogout();

--- a/src/main/vue/src/components/member/ProfileEdit.vue
+++ b/src/main/vue/src/components/member/ProfileEdit.vue
@@ -203,8 +203,8 @@
         fetch(uploadUrl, option)
         .then(response => response.json())
         .then(data=>{
-            console.log("이미지요청 완료!");
-            console.log(data);
+            //헤더 프로필 이미지 정보 갱신
+            memberInfo.profileImagePath = data.name;
             showimageChangeModal(); //흑
             
 	})


### PR DESCRIPTION
## 🛠 작업사항
- 마이프로필에서 프로필 사진 업데이트 시 사용자 프로필이 업데이트되지 않는 부분을 수정하였습니다.
- 프로필 사진 업데이트 시 한글파일을 업로드하거나, 또는 파일명이 중복되는 것을 올릴 때 발생할 수 있는 부분을 수정하였습니다.
### 수정 전
- 사용자가 자신의 프로필 사진을 업데이트할 때 profileFile이라는 테이블에 프로필 사진이 정상적으로 업로드 되나, 프로필 개시자의 memberId가 반영되지 않는 부분과 member테이블에서 profileImagePath가 업데이트되지 않는 문제가 있었음
- 프로필 사진 업데이트 시 파일명에 한글이 들어가는 경우 불러오는데 실패하고,  파일명이 중복된 이미지를 올릴 경우 덮어써지는 문제가 있음.

### 수정 후
- memberId를 userDetails에서 받아 profileFile테이블을 업데이트하도록 변경
- member테이블을 업데이트하도록 코드 추가
- 이미지 명은 ZPOP_PROFILE_'YYYY_MM_DD_HH_mm_SS_SSS' 로 업데이트 되도록 수정 (이로 인한 테이블 제약조건 수정 name의 VARCHAR(30) => VARCHAR(40)
- 프로필 업데이트 성공 시 백엔드에서 profileFile을 response로 보내고, 거기에 있는 파일명을 이용해 헤더 이미지를 수정하도록 변경

## 💡 기타
- N/A
