### PR TITLE
fix: 모임글 작성 시 jpeg 형식 이미지 업로드되지 않는 부분 수정

### DIFF
--- a/src/main/vue/src/utils/quill-generator.js
+++ b/src/main/vue/src/utils/quill-generator.js
@@ -111,8 +111,7 @@ function isImage(filename) {
     case 'bmp':
     case 'png':
     case 'svg':
-      //etc
-      return true;
+	return true;
   }
   return false;
 }

--- a/src/main/vue/src/utils/quill-generator.js
+++ b/src/main/vue/src/utils/quill-generator.js
@@ -106,6 +106,7 @@ function isImage(filename) {
  let ext = getExtension(filename);
   switch (ext.toLowerCase()) {
     case 'jpg':
+	case 'jpeg':
     case 'gif':
     case 'bmp':
     case 'png':


### PR DESCRIPTION
## 🛠 작업사항
-모임글 작성 시 jpeg 형식의 파일이 업로드되지 않는 부분 수정

### 수정 전
- jpeg는 이미지 형식 case에서 제외되어 있었음

### 수정 후 
- jpeg를 이미지 형식 case에서 포함시킴