### PR TITLE
fix: 닉네임 설정 화면에서 닉네임이 공란일 때 로그인 설정버튼을 누르면 넘어가는 버그 수정

### DIFF
--- a/src/main/vue/src/components/modal/NicknameRegister.vue
+++ b/src/main/vue/src/components/modal/NicknameRegister.vue
@@ -124,8 +124,9 @@ const nicknameChangeHandler = (event) => {
 
 const validateNickname = () => {
     
-    if (nickname.value.length === 0) return;
-
+    if (nickname.value.length === 0) {
+        throw new Error('닉네임은 공백이 될 수 없어요!');
+    }
     if (nickname.value.length > maxNicknameLength){
         throw new Error('닉네임은 10글자 이하로 입력해주세요!');
     }


### PR DESCRIPTION
## 🛠 작업사항
- 닉네임 설정 화면에서 닉네임이 공란일 때 로그인 설정버튼을 누르면 넘어가는 버그를 수정했음
### 수정 전
- 닉네임 설정화면에서 닉네임이 공란일 때 예외가 발생하지 않아 다음 페이지로 넘어가는 버그가 있었음.
- 넘어가긴 해도 실제로 db에 회원등록으로 이어지지는 않았음

### 수정 후
- 닉네임 설정화면에서 닉네임이 공란이면 예외가 발생하도록 코드를 수정
```js
const validateNickname = () => {
    // 생략
    if (nickname.value.length === 0) {
        throw new Error('닉네임은 공백이 될 수 없어요!');
    }
    if (nickname.value.length > maxNicknameLength){
        throw new Error('닉네임은 10글자 이하로 입력해주세요!');
    }
   // 생략
```
## 💡 기타
- N/A
