### PR TITLE
fix: 닉네임 설정화면에서 닉네임 설정 후 greeting modal에서 닉네임이 하드코딩된 문제 수정

### DIFF
--- a/src/main/vue/src/components/modal/NicknameRegister.vue
+++ b/src/main/vue/src/components/modal/NicknameRegister.vue
@@ -7,7 +7,7 @@
             <div class="modal__body">
                 <div class="modal__contents">
                     <Transition name="content1">
-                        <div class="modal__content" v-show="!isRegisteredSuccessful">
+                        <div class="modal__content" v-show="(memberStore.nickname == '' || memberStore.nickname == null)">
                             <div class="logo-img">
                                 <img src="../../../public/images/logo/logo-modal.svg" alt="" class="src">
                             </div>
@@ -25,13 +25,13 @@
                         </div>
                     </Transition>
                     <Transition name="content2">
-                        <div class="modal__content" v-show="isRegisteredSuccessful">
+                        <div class="modal__content" v-show="(memberStore.nickname != '' && memberStore.nickname != null)">
                             <div class="greetings">
                                 <p>
                                     <img src="../../../public/images/logo/logo-only-text.svg"><span>에 오신걸 환영해요!</span>
                                 </p>
                                 <p>
-                                    😉 집합에 새로오신 ‘<span class="greetings__nickname">나홀로집에</span>’님!
+                                    😉 집합에 새로오신 ‘<span class="greetings__nickname">{{memberStore.nickname}}</span>’님!
                                 </p>
                             </div>
                             <div class="pros">


### PR DESCRIPTION
## 🛠 작업사항
- 닉네임 수정 후 greeting 모달에서 닉네임이 하드코딩된 문제를 수정하였음
### 수정 전
- 모달에 '나홀로집에' 가 하드코딩되어 있었음
### 수정 후
- 닉네임을 업데이트 한 후 서버에서 사용자 인증정보를 다시 불러올 때 받아온 닉네임이 있는 경우 설정된 닉네임이 표시되고, 모달이 전환되도록 수정

## 💡 기타
- N/A
