### PR TITLE
fix: 작성된 댓글에서 댓글 작성자의 프로필 이미지가 보이지 않는 버그 수정

### DIFF
--- a/src/main/java/com/zpop/web/controller/ReplyController.java
+++ b/src/main/java/com/zpop/web/controller/ReplyController.java
@@ -33,8 +33,9 @@ public class ReplyController {
 			memberId = userDetails.getId();
 		if(memberId != 0)
 			replies = service.getReplyWithWriter(memberId, groupId);
-		else
+		else{
 			replies = service.getReply(groupId);
+		}
 		int countOfReply = service.getCountOfReply(groupId);
 
 		Map<String,Object> dto = new HashMap<>();

--- a/src/main/java/com/zpop/web/dto/CommentResponse.java
+++ b/src/main/java/com/zpop/web/dto/CommentResponse.java
@@ -2,13 +2,22 @@ package com.zpop.web.dto;
 
 import java.util.Date;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommentResponse {
   private int id;
 	private int meetingId;
 	private int writerId;
 	private String nickname;
 	private String content;
-	private String profileImgPath;
+	private String profileImagePath;
 	private int parentCommentId;
 	private int groupId;
 	private Date createdAt;
@@ -20,170 +29,5 @@ public class CommentResponse {
 	private String elapsedTime;
 	private int countOfReply; //한 그룹내의 답글 수
 	private boolean isMyComment;//본인작성글 여부
-
-  public CommentResponse() {
-  }
-
-
-
-  public CommentResponse(int id, int meetingId, int writerId, String nickname, String content, String profileImgPath,
-		int parentCommentId, int groupId, Date createdAt, Date updatedAt, Date deletedAt, int parentMemberId,
-		String parentNickname, String parentImg, String elapsedTime, int countOfReply, boolean isMyComment) {
-	this.id = id;
-	this.meetingId = meetingId;
-	this.writerId = writerId;
-	this.nickname = nickname;
-	this.content = content;
-	this.profileImgPath = profileImgPath;
-	this.parentCommentId = parentCommentId;
-	this.groupId = groupId;
-	this.createdAt = createdAt;
-	this.updatedAt = updatedAt;
-	this.deletedAt = deletedAt;
-	this.parentMemberId = parentMemberId;
-	this.parentNickname = parentNickname;
-	this.parentImg = parentImg;
-	this.elapsedTime = elapsedTime;
-	this.countOfReply = countOfReply;
-	this.isMyComment = isMyComment;
-}
-
-
-
-public int getId() {
-    return this.id;
-  }
-
-  public void setId(int id) {
-    this.id = id;
-  }
-
-  public int getMeetingId() {
-    return this.meetingId;
-  }
-
-  public void setMeetingId(int meetingId) {
-    this.meetingId = meetingId;
-  }
-
-  public int getWriterId() {
-    return this.writerId;
-  }
-
-  public void setWriterId(int writerId) {
-    this.writerId = writerId;
-  }
-
-  public String getNickname() {
-    return this.nickname;
-  }
-
-  public void setNickname(String nickname) {
-    this.nickname = nickname;
-  }
-
-  public String getContent() {
-    return this.content;
-  }
-
-  public void setContent(String content) {
-    this.content = content;
-  }
-
-  public String getProfileImgPath() {
-    return this.profileImgPath;
-  }
-
-  public void setProfileImgPath(String profileImgPath) {
-    this.profileImgPath = profileImgPath;
-  }
-
-  public int getParentCommentId() {
-    return this.parentCommentId;
-  }
-
-  public void setParentCommentId(int parentCommentId) {
-    this.parentCommentId = parentCommentId;
-  }
-
-  public int getGroupId() {
-    return this.groupId;
-  }
-
-  public void setGroupId(int groupId) {
-    this.groupId = groupId;
-  }
-
-  public Date getCreatedAt() {
-    return this.createdAt;
-  }
-
-  public void setCreatedAt(Date createdAt) {
-    this.createdAt = createdAt;
-  }
-
-  public Date getUpdatedAt() {
-	return updatedAt;
-}
-
-public void setUpdatedAt(Date updatedAt) {
-	this.updatedAt = updatedAt;
-}
-
-public Date getDeletedAt() {
-    return this.deletedAt;
-  }
-
-  public void setDeletedAt(Date deletedAt) {
-    this.deletedAt = deletedAt;
-  }
-
-  public int getParentMemberId() {
-    return this.parentMemberId;
-  }
-
-  public void setParentMemberId(int parentMemberId) {
-    this.parentMemberId = parentMemberId;
-  }
-
-  public String getParentNickname() {
-    return this.parentNickname;
-  }
-
-  public void setParentNickname(String parentNickname) {
-    this.parentNickname = parentNickname;
-  }
-
-  public String getParentImg() {
-    return this.parentImg;
-  }
-
-  public void setParentImg(String parentImg) {
-    this.parentImg = parentImg;
-  }
-
-  public String getElapsedTime() {
-    return this.elapsedTime;
-  }
-
-  public void setElapsedTime(String elapsedTime) {
-    this.elapsedTime = elapsedTime;
-  }
-
-  public int getCountOfReply() {
-    return this.countOfReply;
-  }
-
-  public void setCountOfReply(int countOfReply) {
-    this.countOfReply = countOfReply;
-  }
-
-  public boolean isMyComment() {
-    return this.isMyComment;
-  }
-
-  public void setMyComment(boolean isMyComment) {
-    this.isMyComment = isMyComment;
-  }
 
 }

--- a/src/main/java/com/zpop/web/entity/comment/CommentView.java
+++ b/src/main/java/com/zpop/web/entity/comment/CommentView.java
@@ -2,13 +2,24 @@ package com.zpop.web.entity.comment;
 
 import java.util.Date;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
 public class CommentView {
 	private int id;
 	private int meetingId;
 	private int writerId;
 	private String nickname;
 	private String content;
-	private String profileImgPath;
+	private String profileImagePath;
 	private int parentCommentId;
 	private int groupId;
 	private Date createdAt;
@@ -20,107 +31,8 @@ public class CommentView {
 	private String elapsedTime;
 	private int countOfReply; //한 그룹내의 답글 수
 	private boolean isMyComment;//본인작성글 여부
-	
-	public CommentView() {
-	}
 
 	public CommentView(int i) {
 		this.groupId = i;
 	}
-
-	public int getId() {
-		return id;
-	}
-
-	public int getMeetingId() {
-		return meetingId;
-	}
-
-	public int getWriterId() {
-		return writerId;
-	}
-
-	public String getNickname() {
-		return nickname;
-	}
-
-	public String getContent() {
-		return content;
-	}
-
-	public String getProfileImgPath() {
-		return profileImgPath;
-	}
-
-	public int getParentCommentId() {
-		return parentCommentId;
-	}
-
-	public int getGroupId() {
-		return groupId;
-	}
-
-	public Date getCreatedAt() {
-		return createdAt;
-	}
-
-	public Date getUpdatedAt() {
-		return updatedAt;
-	}
-
-	public Date getDeletedAt() {
-		return deletedAt;
-	}
-
-	public int getParentMemberId() {
-		return parentMemberId;
-	}
-
-	public String getParentNickname() {
-		return parentNickname;
-	}
-
-	public String getParentImg() {
-		return parentImg;
-	}
-
-	public String getElapsedTime() {
-		return elapsedTime;
-	}
-
-	public void setElapsedTime(String elapsedTime) {
-		this.elapsedTime = elapsedTime;
-	}
-
-	public int getCountOfReply() {
-		return countOfReply;
-	}
-
-	public void setCountOfReply(int countOfReply) {
-		this.countOfReply = countOfReply;
-	}
-
-	public boolean isMyComment() {
-		return isMyComment;
-	}
-
-	public void setMyComment(boolean isMyComment) {
-		this.isMyComment = isMyComment;
-	}
-
-	@Override
-	public String toString() {
-		return "CommentView [id=" + id + ", meetingId=" + meetingId + ", nickname=" + nickname + ", content=" + content
-				+ ", profileImgPath=" + profileImgPath + ", parentCommentId=" + parentCommentId + ", groupId=" + groupId
-				+ ", createdAt=" + createdAt + ", parentMemberId=" + parentMemberId + ", parentNickname="
-				+ parentNickname + ", parentImg=" + parentImg + "]";
-	}
-
-	
-
-	
-
-	
-	
-	
 }

--- a/src/main/java/com/zpop/web/service/DefaultMeetingService.java
+++ b/src/main/java/com/zpop/web/service/DefaultMeetingService.java
@@ -278,7 +278,7 @@ public class DefaultMeetingService implements MeetingService {
 					c.getWriterId(),
 					c.getNickname(),
 					c.getContent(),
-					c.getProfileImgPath(),
+					c.getProfileImagePath(),
 					c.getParentCommentId(),
 					c.getGroupId(),
 					c.getCreatedAt(),

--- a/src/main/vue/src/assets/css/meeting/component/profile-box.css
+++ b/src/main/vue/src/assets/css/meeting/component/profile-box.css
@@ -16,11 +16,14 @@
 .profile__image {
   width: 2.25rem;
   height: 2.25rem;
-  background-image: url("../../../../../public/images/icon/user-profile-grey.svg");
-  background-size: contain;
   display: inline-block;
   grid-area: img;
   cursor: pointer;
+}
+
+.profile__image > img{
+  width:100%;
+  border-radius: 1.125rem;
 }
 
 .profile__nickname {
@@ -70,5 +73,8 @@
   .profile__image {
     width: 2.5rem;
     height: 2.5rem;
+  }
+  .profile__image > img{
+    border-radius: 1.25rem;
   }
 }

--- a/src/main/vue/src/components/comment/Comment.vue
+++ b/src/main/vue/src/components/comment/Comment.vue
@@ -107,7 +107,8 @@
 
 <template>
   <div class="profile select-box">
-    <span class="profile__image"></span>
+    <span class="profile__image"><img :src="(comment.profileImagePath != '' && comment.profileImagePath != null)
+          ? `/image/profile/${comment.profileImagePath}` : '/images/icon/user-profile-grey.svg'"></span>
     <span class="profile__nickname">{{ comment.nickname }}</span>
     <span class="profile__time">{{ comment.updatedAt?comment.elapsedTime+' (수정됨)':comment.elapsedTime }}</span>
     <button @click="toggleSelectModal"></button>

--- a/src/main/vue/src/components/comment/Reply.vue
+++ b/src/main/vue/src/components/comment/Reply.vue
@@ -111,7 +111,8 @@
 
 <template>
      <div class="profile select-box">
-        <span class="profile__image"></span>
+        <span class="profile__image"><img :src="(reply.profileImagePath != '' && reply.profileImagePath != null)
+          ? `/image/profile/${reply.profileImagePath}` : '/images/icon/user-profile-grey.svg'"></span>
         <span class="profile__nickname profile__nickname">{{ reply.nickname }}</span>
         <span class="profile__time">{{ reply.updatedAt?reply.elapsedTime+' (수정됨)':reply.elapsedTime }}</span>
         <button @click="toggleSelectModal"></button>

--- a/src/main/vue/src/components/meeting/article/Article.vue
+++ b/src/main/vue/src/components/meeting/article/Article.vue
@@ -251,5 +251,8 @@ function handleMeetingReportModal() {
 }
 }
 
+:deep(.content-container img){
+  max-width:100%;
+}
 
 </style>


### PR DESCRIPTION
## 🛠 작업사항
-<img width="421" alt="image" src="https://user-images.githubusercontent.com/102606939/216010126-d7e15056-3a1a-436e-967c-ebe8aff95917.png">
### 수정 전
- 댓글, 대댓글에 작성자 프로필이 기본 프로필로만 보이는 이슈가 있었음
- <span>태그에 background-image 속성으로 기본 프로필(회색)을 보여주는 상황이라, <img> 태그를 추가할 필요가 있었음
- db에서 groupId를 통해 commentView를 받아올 때, dto의 속성 중 'profileImgPath' 가 db의 컬럼명인 'profileImagePath' 와 맞지 않아 db에서는 조회가 돼도 dto에 값을 넘겨주지 못하는 이슈가 있었음
### 수정 후
- <img> 태그를 안에 넣고, 프로필 이미지 경로를 :src에 바인딩해주었음 (& 관련 css 수정)
- db의 member 컬럼명과 동일한 profileImagePath로 commentView를 수정하였고, getter와 setter 및 생성자를 지우고 lombok 적용하였음
## 💡 기타
- N/A
