### PR TITLE
fix: default modal z-index, comment kebob bg color

### DIFF
--- a/src/main/vue/src/assets/css/meeting/component/profile-box.css
+++ b/src/main/vue/src/assets/css/meeting/component/profile-box.css
@@ -43,7 +43,6 @@
   background-image: url(../../../../../public/images/icon/kebab.svg);
   background-repeat: no-repeat;
   border: none;
-  background-color: var(--white);
   grid-area: button;
   justify-self: flex-end;
   margin-top: 0.438rem;

--- a/src/main/vue/src/components/modal/Default.vue
+++ b/src/main/vue/src/components/modal/Default.vue
@@ -36,6 +36,7 @@ function closeModal(e) {
   background-color: rgba(0, 0, 0, 0.15);
   position: fixed;
   inset: 0; /*t, l, b, r 0*/
+  z-index:998;
 }
 
 .modal-default {


### PR DESCRIPTION
## 🛠 작업사항
- 모달의 wrapper에 z index가 없어서 998로 지정하여 모달의 999바로 하단에 위치하게 함으로써 다른 화면내 다른요소들과의 배경색 충돌을 방지함.
