### PR TITLE
fix: 닉네임 입력 없이 프로필 수정 되던 현상 수정

### DIFF
--- a/src/main/java/com/zpop/web/service/DefalutMemberService.java
+++ b/src/main/java/com/zpop/web/service/DefalutMemberService.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import io.micrometer.common.util.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -320,7 +321,7 @@ public class DefalutMemberService implements MemberService {
 	@Override
 	public Member update(int memberId, String nickname, String imageName) {
         // 닉네임 변경
-        if(nickname != null) {
+        if(!StringUtils.isBlank(nickname)) {
             changeNickname(memberId, nickname);
         }
 


### PR DESCRIPTION
## 🛠 작업사항
* 닉네임 빈문자열 입력후 프로필 저장하면 닉네임이 빈문자열로 바뀌던 버그 수정

